### PR TITLE
Add national level metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -350,29 +350,5 @@ prose:
       - name: "graph_title"
         field: 
             element: text
-            label: "Graph Title"  
-      - name: "actual_indicator_available"
-        field:
-            element: text
-            label: "Actual indicator available"
-      - name: "actual_indicator_available_description"
-        field:
-            element: textarea
-            label: "Description of actual indicator available"
-      - name: "us_method_of_computation"
-        field:
-            element: textarea
-            label: "Method of computation"
-      - name: "comments_and_limitations"
-        field:
-            element: textarea
-            label: "Comments and limitations"
-      - name: "time_period"
-        field:
-            element: text
-            label: "Time Period"
-      - name: "unit_of_measure"
-        field:
-            element: text
-            label: "Unit of measure"
+            label: "Graph Title"
     

--- a/_config.yml
+++ b/_config.yml
@@ -338,6 +338,15 @@ prose:
             label: "Contact Details"
             scope: source_3
       ######### Chart Info #########
+      - name: "graph_type"
+        field: 
+            element: select 
+            label: "Graph Type"
+            options:
+              - name: 'Longitudinal'
+                value: 'Longitudinal'
+              - name: 'Bar'
+                value: 'Bar'      
       - name: "graph_title"
         field: 
             element: text

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ prose:
   ignore: ['/assets', '/_includes', '/_layouts', '/scripts', '/sass' ]
   metadata:
     _indicators:
-    ######### Global #########
+    ######### Global Metadata #########
       - name: "indicator"
         field:
             element: hidden
@@ -95,12 +95,97 @@ prose:
             element: text
             label: "Link to UN Metadata"
             scope: global
-      ######### UK Sources #########
+      ######### National Metadata #########
+      - name: "national_indicator_available"
+        field:
+            element: text
+            label: "Actual Indicator Available"
+            scope: national
+      - name: "national_indicator_description"
+        field:
+            element: text
+            label: "Actual Indicator Description"
+            scope: national
+      - name: "national_indicator_periodicity"
+        field:
+            element: text
+            label: "Indicator Periodicity"
+            scope: national
+      - name: "national_earliest_available_data"
+        field:
+            element: text
+            label: "Earliest Available Data"
+            scope: national
+      - name: "national_geographical_coverage"
+        field:
+            element: text
+            label: "Geographic Coverage"
+            scope: national
+      - name: "admin_release_date"
+        field:
+            element: text
+            label: "Release Date"
+            help: "A date in YYYY-MM-DD format"
+            placeholder: "YYYY-MM-DD"
+            scope: national
+      - name: "admin_next_release"
+        field:
+            element: text
+            label: "Next Release"
+            help: "A date in YYYY-MM-DD format"
+            placeholder: "YYYY-MM-DD"
+            scope: national
+      - name: "admin_statistical_classification"
+        field:
+            element: text
+            label: "Statistical Classification"
+            scope: national
+      - name: "admin_contact_details"
+        field:
+            element: text
+            label: "Contact Details"
+            scope: national
+      - name: "computation_method"
+        field:
+            element: text
+            label: "Method of Computation"
+            scope: national
+      - name: "computation_definitions"
+        field:
+            element: text
+            label: "Definitions Used"
+            scope: national
+      - name: "computation_calculations"
+        field:
+            element: text
+            label: "Calculations"
+            scope: national
+      - name: "computation_numerator"
+        field:
+            element: text
+            label: "Numerator"
+            scope: national
+      - name: "computation_denominator"
+        field:
+            element: text
+            label: "Denominator"
+            scope: national
+      - name: "computation_disaggregation"
+        field:
+            element: text
+            label: "Disaggregation"
+            scope: national
+      - name: "computation_comments"
+        field:
+            element: text
+            label: "Comments and Limitations"
+            scope: national
+      ######### National Sources #########
       ## Source 1
       - name: source_active_1
         field:
             element: checkbox
-            label: Source Active
+            label: Source 1 Active
             help: Whether or not to display this source
             value: true
       - name: source_organisation_1
@@ -152,7 +237,7 @@ prose:
       - name: source_active_2
         field:
             element: checkbox
-            label: Source Active
+            label: Source 2 Active
             help: Whether or not to display this source
             value: false
       - name: source_organisation_2
@@ -200,6 +285,58 @@ prose:
             element: text
             label: "Contact Details"
             scope: source_2
+      ## Source 3
+      - name: source_active_3
+        field:
+            element: checkbox
+            label: Source 3 Active
+            help: Whether or not to display this source
+            value: false
+      - name: source_organisation_3
+        field:
+            element: text
+            label: "Organisation"
+            scope: source_3
+      - name: "source_periodicity_3"
+        field:
+            element: text
+            label: "Periodicity"
+            scope: source_3
+      - name: "source_earliest_available_3"
+        field:
+            element: text
+            label: "Earliest Available Data"
+            scope: source_3
+      - name: "source_geographical_coverage_3"
+        field:
+            element: text
+            label: "Geographical Coverage"
+            scope: source_3
+      - name: "source_link_3"
+        field:
+            element: text
+            label: "Link"
+            scope: source_3
+      - name: "source_release_date_3"
+        field:
+            element: text
+            label: "Release Date"
+            scope: source_3
+      - name: "source_next_release_3"
+        field:
+            element: text
+            label: "Next Release Date"
+            scope: source_3
+      - name: "source_statistical_classification_3"
+        field:
+            element: text
+            label: "Statistical Classification"
+            scope: source_3
+      - name: "source_contact_3"
+        field:
+            element: text
+            label: "Contact Details"
+            scope: source_3
       ######### Chart Info #########
       - name: "graph_title"
         field: 
@@ -229,51 +366,4 @@ prose:
         field:
             element: text
             label: "Unit of measure"
-      - name: "disaggregation_categories"
-        field:
-            element: text
-            label: "Disaggregation #1 (Industry or social categories)"
-      - name: "disaggregation_geography"
-        field:
-            element: text
-            label: "Disaggregation #2 (Geographical coverage)"
-      - name: "date_of_national_source_publication"
-        field:
-            element: text
-            label: "Date of public data release from National source"
-            placeholder: "MONTH YEAR"
-      - name: "date_metadata_updated"
-        field:
-            element: text
-            label: "Date of last Update of This Page"
-            placeholder: "MONTH YEAR"
-      - name: "scheduled_update_by_national_source"
-        field:
-            element: text
-            label: "Scheduled Update by National source"
-            placeholder: "MONTH/YEAR (Next Agency Release)"
-      - name: "scheduled_update_by_SDG_team"
-        field:
-            element: text
-            label: "Scheduled Update by SDG Team"
-            placeholder: "MONTH/YEAR (NRP Database)"
-      - name: "source_agency_staff_name"
-        field:
-            element: text
-            label: "Data Source1 (Agency STAFF NAME)"
-      - name: "source_agency_staff_email"
-        field:
-            element: text
-            label: "Data Source2 (Staff E-MAIL)"
-      - name: "source_agency_survey_dataset"
-        field:
-            element: text
-            label: "Data Source3 (Agency/Survey/Dataset name)"
-      - name: "source_url"
-        field:
-            element: text
-            label: "Indicator web address (closest to data provided)"
-      - name: "international_and_national_references"
-        field:
-            element: text
-            label: "International and National References"
+    

--- a/_indicators/14-2-1.md
+++ b/_indicators/14-2-1.md
@@ -35,6 +35,7 @@ date_metadata_updated: null
 scheduled_update_by_national_source: null
 scheduled_update_by_SDG_team: null
 source_active_1: true
+source_active_2: true
 source_agency_staff_name: null
 source_agency_staff_email: null
 source_agency_survey_dataset: null

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -120,10 +120,16 @@
   
         {% if n_sources > 0 %}
           <h2>Data Source{% if n_sources > 1 %}s{% endif %} Metadata</h2>
+
+        
+            
+          <div class="row no-gutters">
           {% for i in (1..n_sources) %}
             {% assign src_active = "source_active_" | append: i %}
             {% assign src_scope = "source_" | append: i %}
-            <h3>Source {{ i }}</h3>
+
+            <div class="col-md-6">
+              <h3>Source {{ i }}</h3>
               <table>
               {% for indicator_metadata in site.prose.metadata._indicators %}
                 {% if indicator_metadata.field.scope == src_scope %}
@@ -134,7 +140,9 @@
                 {% endif %}
               {% endfor %}
               </table>
+            </div>
             {% endfor %}
+            </div>
           {% endif %}
         </div>
   </div>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -70,52 +70,73 @@
       <a href="{{ site.baseurl }}/data/{{ dataset_name }}.csv" class="btn btn-primary download-csv">Download source CSV</a>
     </div>
     <div role="tabpanel" class="tab-pane" id="metadata">
-      <h2>Global Metadata</h2>
-      <p>
-        This table provides information on metadata for SDG indicators as defined by the UNSC. Complete global <a href="{{ this_sdg_indicator_metadata.goal_meta_link }}">metadata documentation on all indicators in Goal {{ page_goal_num }}</a> is provided by the UN Statistics Division.
-      </p>
-      <table class="table table-hover">
-        {% for indicator_metadata in site.prose.metadata._indicators %}
-          {% if indicator_metadata.field.scope == "global" %}
-            <tr>
-              <th scope="row">  {{ indicator_metadata.field.label }} </th>
-              <td>{{ page[indicator_metadata.name] }}</td>
-            </tr>
+
+      <!-- Global Metadata -->
+      <div id="globalmetadata">
+        <h2>Global Metadata</h2>
+        <p>
+          This table provides information on metadata for SDG indicators as defined by the UNSC. Complete global <a href="{{ this_sdg_indicator_metadata.goal_meta_link }}">metadata documentation on all indicators in Goal {{ page_goal_num }}</a> is provided by the UN Statistics Division.
+        </p>
+        <table class="table table-hover">
+          {% for indicator_metadata in site.prose.metadata._indicators %}
+            {% if indicator_metadata.field.scope == "global" %}
+              <tr>
+                <th scope="row">  {{ indicator_metadata.field.label }} </th>
+                <td>{{ page[indicator_metadata.name] }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </table>
+      </div>
+
+      <!-- National Metadata -->
+      <div id="nationalmetadata">
+        <h2>National Metadata</h2>
+          <p>This table provides metadata for the actual indicator available from {{ site.country.name }} statistics closest to the corresponding global
+            SDG indicator. Please note that even when the global SDG indicator is fully available from {{ site.country.adjective }} statistics, this table
+            should be consulted for information on national methodology and other {{ site.country.adjective }}-specific metadata information.
+          </p>
+        <table class="table table-hover">
+          {% for indicator_metadata in site.prose.metadata._indicators %}
+            {% if indicator_metadata.field.scope == "national" %}
+              <tr>
+                <th scope="row">  {{ indicator_metadata.field.label }} </th>
+                <td>{{ page[indicator_metadata.name] }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </table>
+      </div>
+
+      <div id="sourcemetadata">
+        <!-- Count the non-empty sources (up to 5) -->
+        {% assign n_sources = 0 %}
+        {% for i in (1..5) %}
+          {% assign src_active = "source_active_" | append: i %}
+          {% if page[src_active] == true %}
+            {% assign n_sources  = n_sources | plus: 1 %}
           {% endif %}
         {% endfor %}
-      </table>
-
-      {% assign n_sources = 0 %}
-      {% for i in (1..5) %}
-        {% assign src_active = "source_active_" | append: i %}
-        {% if page[src_active] == true %}
-          {% assign n_sources  = n_sources | plus: 1 %}
-        {% endif %}
-      {% endfor %}
-
-      {% if n_sources > 0 %}
-        <h2>Data Source(s) Metadata</h2>
-        <p>
-          This table provides metadata for the actual indicator available from {{ site.country.name }} statistics closest to the corresponding global
-          SDG indicator. Please note that even when the global SDG indicator is fully available from {{ site.country.adjective }} statistics, this table
-          should be consulted for information on national methodology and other {{ site.country.adjective }}-specific metadata information
-        </p>
-        {% for i in (1..n_sources) %}
-          {% assign src_active = "source_active_" | append: i %}
-          {% assign src_scope = "source_" | append: i %}
-          <h3>Source {{ i }}</h3>
-            <table>
-            {% for indicator_metadata in site.prose.metadata._indicators %}
-              {% if indicator_metadata.field.scope == src_scope %}
-                <tr>
-                  <th>{{ indicator_metadata.field.label }}</th>
-                  <td>{{ page[indicator_metadata.name] }}</td>
-                </tr>
-              {% endif %}
+  
+        {% if n_sources > 0 %}
+          <h2>Data Source{% if n_sources > 1 %}s{% endif %} Metadata</h2>
+          {% for i in (1..n_sources) %}
+            {% assign src_active = "source_active_" | append: i %}
+            {% assign src_scope = "source_" | append: i %}
+            <h3>Source {{ i }}</h3>
+              <table>
+              {% for indicator_metadata in site.prose.metadata._indicators %}
+                {% if indicator_metadata.field.scope == src_scope %}
+                  <tr>
+                    <th>{{ indicator_metadata.field.label }}</th>
+                    <td>{{ page[indicator_metadata.name] }}</td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
+              </table>
             {% endfor %}
-            </table>
-          {% endfor %}
-        {% endif %}
+          {% endif %}
+        </div>
   </div>
 
   {% if site.github.environment == 'dotcom' %}


### PR DESCRIPTION
- Updates the prose configuration and indicator.html to support a `national` scope.
- Adds a third data source (turned off by default)
- Remove unused (at least in the UK) metadata fields from prose config

