### PR TITLE
Fixes Unordered X Axis labels on plots

### DIFF
--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -60,7 +60,7 @@ var indicatorModel = function(options) {
         that = this,
         seriesData = [],
         tableData = [],
-        years = _.chain(this.data).pluck('Year').uniq().sortBy(function(d) { return d.Year; }).value(),
+        years = _.chain(this.data).pluck('Year').uniq().sortBy(function(year) { return +year; }).value(),
         allFunc = function() {
           return _.chain(that.data)
             .filter(function(i) { return that.allNull(i, selectableFields); })

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -60,7 +60,7 @@ var indicatorModel = function(options) {
         that = this,
         seriesData = [],
         tableData = [],
-        years = _.chain(this.data).pluck('Year').uniq().sortBy(function(year) { return +year; }).value(),
+        years = _.chain(this.data).pluck('Year').uniq().sortBy(function(year) { return year; }).value(),
         allFunc = function() {
           return _.chain(that.data)
             .filter(function(i) { return that.allNull(i, selectableFields); })


### PR DESCRIPTION
The `years` variable was never sorted correctly, because the anonymous function was incorrect. By that point in the chain, it was a string, so didn't have the `Year` property. All values for sorting were therefore `undefined`.

The issue was found because the 'all' year data was a subset of subsequent `year` values, so the years were returned 'as found'.

Sorting is now done correctly.