### PR TITLE
Cache busting for assets

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,15 +1,14 @@
-<script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-crossorigin="anonymous"></script>
+<script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.bundle.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script src="//cdn.datatables.net/1.10.13/js/dataTables.bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-<script src='{{ site.baseurl }}/assets/js/event.js'></script>
-<script src='{{ site.baseurl }}/assets/js/indicatorModel.js'></script>
-<script src="{{ site.baseurl }}/assets/js/indicatorView.js"></script>
-<script src="{{ site.baseurl }}/assets/js/indicatorController.js"></script>
+<script src='{{ site.baseurl }}/assets/js/event.js?v={{ cache_bust }}'></script>
+<script src='{{ site.baseurl }}/assets/js/indicatorModel.js?v={{ cache_bust }}'></script>
+<script src="{{ site.baseurl }}/assets/js/indicatorView.js?v={{ cache_bust }}"></script>
+<script src="{{ site.baseurl }}/assets/js/indicatorController.js?v={{ cache_bust }}"></script>
 <script>
 $(function() {
     $(window).scroll(function() {


### PR DESCRIPTION
Jekyll generated timestamp so new releases are deemed 'updated' by browsers.