### PR TITLE
Fixes #124 add hierachical data

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -384,6 +384,11 @@ prose:
             element: textarea
             label: "Other Information"
             scope: source_3
+      ######### Data Info #########
+      - name: "data_edge_list"
+        field: 
+            element: text
+            label: "Data Hierachy Edge List"
       ######### Chart Info #########
       - name: "graph_type"
         field: 

--- a/_indicators/14-1-1.md
+++ b/_indicators/14-1-1.md
@@ -41,10 +41,16 @@ indicator_definition: Index of Coastal Eutrophication (ICEP) Floating Plastic De
 source_title: null
 source_notes: null
 published: true
-dougtest: protected branch
+national_indicator_available: "Demo Data Set"
+national_indicator_description: "This is a demonstration data set to show different features of this website."
+national_indicator_periodicity: "Annual"
+national_geographical_coverage: "Inner Solar System"
+computation_units: "Percentage"
 source_active_1: true
+source_organisation_1: "Test Organisation"
+source_geographical_coverage_1: "Solar System"
 source_active_2: false
 source_active_3: false
 graph_type: Longitudinal
-method_of_computation: hello
+data_edge_list: "2:3"
 ---

--- a/data/indicator_14-1-1.csv
+++ b/data/indicator_14-1-1.csv
@@ -1,106 +1,316 @@
-Year,Grade,Planet,Fruit,Value
-2010,,,,15.1591
-2011,,,,16.3583
-2012,,,,16.2244
-2013,,,,14.3392
-2014,,,,15.79
-2015,,,,14.0988
-2016,,,,15.5934
-2010,A,,,14.1695
-2010,B,,,16.1488
-2011,A,,,15.5065
-2011,B,,,17.2102
-2012,A,,,16.6152
-2012,B,,,15.8335
-2013,A,,,14.3857
-2013,B,,,14.2927
-2014,A,,,14.6857
-2014,B,,,16.8942
-2015,A,,,14.8525
-2015,B,,,13.3451
-2016,A,,,16.5992
-2016,B,,,14.5875
-2010,A,Mercury,,17.3458
-2010,A,Venus,,13.3825
-2010,A,Earth,,11.7802
-2010,B,Mercury,,16.4394
-2010,B,Venus,,16.5942
-2010,B,Earth,,15.4127
-2011,A,Mercury,,15.669
-2011,A,Venus,,16.9856
-2011,A,Earth,,13.8649
-2011,B,Mercury,,13.2586
-2011,B,Venus,,19.4585
-2011,B,Earth,,18.9134
-2012,A,Mercury,,16.2654
-2012,A,Venus,,18.3479
-2012,A,Earth,,15.2324
-2012,B,Mercury,,15.6618
-2012,B,Venus,,13.9548
-2012,B,Earth,,17.8839
-2013,A,Mercury,,11.8379
-2013,A,Venus,,16.8824
-2013,A,Earth,,14.4367
-2013,B,Mercury,,11.1883
-2013,B,Venus,,16.0526
-2013,B,Earth,,15.6371
-2014,A,Mercury,,16.2951
-2014,A,Venus,,10.9936
-2014,A,Earth,,16.7684
-2014,B,Mercury,,14.5468
-2014,B,Venus,,19.9637
-2014,B,Earth,,16.1722
-2015,A,Mercury,,13.309
-2015,A,Venus,,16.5238
-2015,A,Earth,,14.7246
-2015,B,Mercury,,11.8639
-2015,B,Venus,,14.424
-2015,B,Earth,,13.7473
-2016,A,Mercury,,16.5154
-2016,A,Venus,,14.8001
-2016,A,Earth,,18.4822
-2016,B,Mercury,,12.4133
-2016,B,Venus,,15.1595
-2016,B,Earth,,16.1897
-2010,,Mercury,,16.8926
-2010,,Venus,,14.9884
-2010,,Earth,,13.5965
-2011,,Mercury,,14.4638
-2011,,Venus,,18.222
-2011,,Earth,,16.3891
-2012,,Mercury,,15.9636
-2012,,Venus,,16.1514
-2012,,Earth,,16.5582
-2013,,Mercury,,11.5131
-2013,,Venus,,16.4675
-2013,,Earth,,15.0369
-2014,,Mercury,,15.4209
-2014,,Venus,,15.4786
-2014,,Earth,,16.4703
-2015,,Mercury,,12.5865
-2015,,Venus,,15.4739
-2015,,Earth,,14.236
-2016,,Mercury,,14.4644
-2016,,Venus,,14.9798
-2016,,Earth,,17.336
-2010,,,Apples,14.8497
-2010,,,Oranges,14.6733
-2010,,,Lemons,15.9544
-2011,,,Apples,13.4712
-2011,,,Oranges,18.2388
-2011,,,Lemons,17.365
-2012,,,Apples,16.4877
-2012,,,Oranges,16.0224
-2012,,,Lemons,16.163
-2013,,,Apples,14.3664
-2013,,,Oranges,13.5446
-2013,,,Lemons,15.1066
-2014,,,Apples,14.7726
-2014,,,Oranges,14.6493
-2014,,,Lemons,17.948
-2015,,,Apples,13.0809
-2015,,,Oranges,13.7446
-2015,,,Lemons,15.4709
-2016,,,Apples,13.7839
-2016,,,Oranges,15.0604
-2016,,,Lemons,17.9358
+"Year","Grade","Planet","Continent","Fruit","Value"
+2010,,,,,6.63
+2011,,,,,7.327
+2012,,,,,7.178
+2013,,,,,6.018
+2014,,,,,6.659
+2015,,,,,6.254
+2016,,,,,6.545
+2010,"A",,,,7.072
+2010,"B",,,,6.187
+2011,"A",,,,7.601
+2011,"B",,,,7.053
+2012,"A",,,,6.191
+2012,"B",,,,8.166
+2013,"A",,,,5.88
+2013,"B",,,,6.156
+2014,"A",,,,6.13
+2014,"B",,,,7.187
+2015,"A",,,,6.151
+2015,"B",,,,6.357
+2016,"A",,,,7.067
+2016,"B",,,,6.022
+2010,,"Earth",,,5.447
+2010,,"Mars",,,8.081
+2010,,"Venus",,,7.407
+2011,,"Earth",,,6.114
+2011,,"Mars",,,7.114
+2011,,"Venus",,,10.679
+2012,,"Earth",,,6.416
+2012,,"Mars",,,6.67
+2012,,"Venus",,,9.848
+2013,,"Earth",,,5.83
+2013,,"Mars",,,7.258
+2013,,"Venus",,,4.629
+2014,,"Earth",,,6.038
+2014,,"Mars",,,6.819
+2014,,"Venus",,,7.97
+2015,,"Earth",,,6.163
+2015,,"Mars",,,5.784
+2015,,"Venus",,,7.187
+2016,,"Earth",,,6.807
+2016,,"Mars",,,4.977
+2016,,"Venus",,,8.239
+2010,,,,"Apples",6.399
+2010,,,,"Lemons",4.99
+2010,,,,"Oranges",8.5
+2011,,,,"Apples",6.804
+2011,,,,"Lemons",7.535
+2011,,,,"Oranges",7.642
+2012,,,,"Apples",8.778
+2012,,,,"Lemons",6.31
+2012,,,,"Oranges",6.448
+2013,,,,"Apples",5.167
+2013,,,,"Lemons",7.164
+2013,,,,"Oranges",5.724
+2014,,,,"Apples",8.171
+2014,,,,"Lemons",6.215
+2014,,,,"Oranges",5.59
+2015,,,,"Apples",5.3
+2015,,,,"Lemons",7.451
+2015,,,,"Oranges",6.011
+2016,,,,"Apples",6.04
+2016,,,,"Lemons",6.944
+2016,,,,"Oranges",6.65
+2010,"A","Earth",,,5.808
+2010,"A","Mars",,,10.454
+2010,"A","Venus",,,5.159
+2010,"B","Earth",,,5.087
+2010,"B","Mars",,,5.708
+2010,"B","Venus",,,9.656
+2011,"A","Earth",,,7.509
+2011,"A","Mars",,,4.902
+2011,"A","Venus",,,11.879
+2011,"B","Earth",,,4.719
+2011,"B","Mars",,,9.327
+2011,"B","Venus",,,9.479
+2012,"A","Earth",,,5.417
+2012,"A","Mars",,,6.027
+2012,"A","Venus",,,8.371
+2012,"B","Earth",,,7.415
+2012,"B","Mars",,,7.312
+2012,"B","Venus",,,11.325
+2013,"A","Earth",,,6.205
+2013,"A","Mars",,,5.256
+2013,"A","Venus",,,6.005
+2013,"B","Earth",,,5.455
+2013,"B","Mars",,,9.261
+2013,"B","Venus",,,3.252
+2014,"A","Earth",,,6.384
+2014,"A","Mars",,,6.642
+2014,"A","Venus",,,4.727
+2014,"B","Earth",,,5.691
+2014,"B","Mars",,,6.996
+2014,"B","Venus",,,11.213
+2015,"A","Earth",,,5.544
+2015,"A","Mars",,,5.625
+2015,"A","Venus",,,8.458
+2015,"B","Earth",,,6.782
+2015,"B","Mars",,,5.944
+2015,"B","Venus",,,5.916
+2016,"A","Earth",,,6.337
+2016,"A","Mars",,,5.195
+2016,"A","Venus",,,11.701
+2016,"B","Earth",,,7.278
+2016,"B","Mars",,,4.76
+2016,"B","Venus",,,4.777
+2010,,"Earth","Africa",,5.807
+2010,,"Earth","America",,5.268
+2010,,"Earth","Asia",,5.557
+2010,,"Earth","Australia",,3.297
+2010,,"Earth","Europe",,7.307
+2010,,"Mars","Dawes",,8.026
+2010,,"Mars","Herschel I",,9.747
+2010,,"Mars","Madler",,6.47
+2010,,"Venus","Aphrodite Terra",,7.414
+2010,,"Venus","Ishtar Terra",,7.401
+2011,,"Earth","Africa",,5.541
+2011,,"Earth","America",,10.331
+2011,,"Earth","Asia",,4.063
+2011,,"Earth","Australia",,5.323
+2011,,"Earth","Europe",,5.311
+2011,,"Mars","Dawes",,4.144
+2011,,"Mars","Herschel I",,5.736
+2011,,"Mars","Madler",,11.463
+2011,,"Venus","Aphrodite Terra",,8.333
+2011,,"Venus","Ishtar Terra",,13.025
+2012,,"Earth","Africa",,6.52
+2012,,"Earth","America",,6.286
+2012,,"Earth","Asia",,7.055
+2012,,"Earth","Australia",,5.92
+2012,,"Earth","Europe",,6.299
+2012,,"Mars","Dawes",,7.208
+2012,,"Mars","Herschel I",,8.899
+2012,,"Mars","Madler",,3.902
+2012,,"Venus","Aphrodite Terra",,9.404
+2012,,"Venus","Ishtar Terra",,10.291
+2013,,"Earth","Africa",,3.502
+2013,,"Earth","America",,8.02
+2013,,"Earth","Asia",,5.249
+2013,,"Earth","Australia",,5.433
+2013,,"Earth","Europe",,6.946
+2013,,"Mars","Dawes",,5.051
+2013,,"Mars","Herschel I",,7.522
+2013,,"Mars","Madler",,9.202
+2013,,"Venus","Aphrodite Terra",,3.031
+2013,,"Venus","Ishtar Terra",,6.226
+2014,,"Earth","Africa",,4.433
+2014,,"Earth","America",,6.215
+2014,,"Earth","Asia",,9.253
+2014,,"Earth","Australia",,5.064
+2014,,"Earth","Europe",,5.223
+2014,,"Mars","Dawes",,7.874
+2014,,"Mars","Herschel I",,8.58
+2014,,"Mars","Madler",,4.004
+2014,,"Venus","Aphrodite Terra",,5.773
+2014,,"Venus","Ishtar Terra",,10.168
+2015,,"Earth","Africa",,0.618
+2015,,"Earth","America",,9.253
+2015,,"Earth","Asia",,7.105
+2015,,"Earth","Australia",,5.234
+2015,,"Earth","Europe",,8.606
+2015,,"Mars","Dawes",,8.513
+2015,,"Mars","Herschel I",,4.821
+2015,,"Mars","Madler",,4.019
+2015,,"Venus","Aphrodite Terra",,7.49
+2015,,"Venus","Ishtar Terra",,6.883
+2016,,"Earth","Africa",,3.85
+2016,,"Earth","America",,8.731
+2016,,"Earth","Asia",,6.442
+2016,,"Earth","Australia",,8.83
+2016,,"Earth","Europe",,6.184
+2016,,"Mars","Dawes",,6.143
+2016,,"Mars","Herschel I",,2.478
+2016,,"Mars","Madler",,6.311
+2016,,"Venus","Aphrodite Terra",,11.232
+2016,,"Venus","Ishtar Terra",,5.246
+2010,"A","Earth","Africa",,7.806
+2010,"A","Earth","America",,3.836
+2010,"A","Earth","Asia",,7.367
+2010,"A","Earth","Australia",,4.303
+2010,"A","Earth","Europe",,5.728
+2010,"A","Mars","Dawes",,7.968
+2010,"A","Mars","Herschel I",,13.268
+2010,"A","Mars","Madler",,10.126
+2010,"A","Venus","Aphrodite Terra",,3.432
+2010,"A","Venus","Ishtar Terra",,6.885
+2010,"B","Earth","Africa",,3.808
+2010,"B","Earth","America",,6.701
+2010,"B","Earth","Asia",,3.748
+2010,"B","Earth","Australia",,2.292
+2010,"B","Earth","Europe",,8.886
+2010,"B","Mars","Dawes",,8.085
+2010,"B","Mars","Herschel I",,6.226
+2010,"B","Mars","Madler",,2.813
+2010,"B","Venus","Aphrodite Terra",,11.396
+2010,"B","Venus","Ishtar Terra",,7.917
+2011,"A","Earth","Africa",,5.264
+2011,"A","Earth","America",,10.742
+2011,"A","Earth","Asia",,7.961
+2011,"A","Earth","Australia",,8.748
+2011,"A","Earth","Europe",,4.828
+2011,"A","Mars","Dawes",,2.028
+2011,"A","Mars","Herschel I",,2.616
+2011,"A","Mars","Madler",,10.062
+2011,"A","Venus","Aphrodite Terra",,8.429
+2011,"A","Venus","Ishtar Terra",,15.328
+2011,"B","Earth","Africa",,5.818
+2011,"B","Earth","America",,9.921
+2011,"B","Earth","Asia",,0.165
+2011,"B","Earth","Australia",,1.897
+2011,"B","Earth","Europe",,5.794
+2011,"B","Mars","Dawes",,6.26
+2011,"B","Mars","Herschel I",,8.856
+2011,"B","Mars","Madler",,12.864
+2011,"B","Venus","Aphrodite Terra",,8.237
+2011,"B","Venus","Ishtar Terra",,10.721
+2012,"A","Earth","Africa",,6.197
+2012,"A","Earth","America",,5.395
+2012,"A","Earth","Asia",,3.987
+2012,"A","Earth","Australia",,5.532
+2012,"A","Earth","Europe",,5.973
+2012,"A","Mars","Dawes",,5.053
+2012,"A","Mars","Herschel I",,7.035
+2012,"A","Mars","Madler",,5.993
+2012,"A","Venus","Aphrodite Terra",,7.151
+2012,"A","Venus","Ishtar Terra",,9.59
+2012,"B","Earth","Africa",,6.844
+2012,"B","Earth","America",,7.177
+2012,"B","Earth","Asia",,10.122
+2012,"B","Earth","Australia",,6.309
+2012,"B","Earth","Europe",,6.625
+2012,"B","Mars","Dawes",,9.363
+2012,"B","Mars","Herschel I",,10.763
+2012,"B","Mars","Madler",,1.81
+2012,"B","Venus","Aphrodite Terra",,11.658
+2012,"B","Venus","Ishtar Terra",,10.993
+2013,"A","Earth","Africa",,3.854
+2013,"A","Earth","America",,5.782
+2013,"A","Earth","Asia",,7.12
+2013,"A","Earth","Australia",,6.714
+2013,"A","Earth","Europe",,7.553
+2013,"A","Mars","Dawes",,1.342
+2013,"A","Mars","Herschel I",,6.523
+2013,"A","Mars","Madler",,7.904
+2013,"A","Venus","Aphrodite Terra",,2.915
+2013,"A","Venus","Ishtar Terra",,9.095
+2013,"B","Earth","Africa",,3.15
+2013,"B","Earth","America",,10.257
+2013,"B","Earth","Asia",,3.379
+2013,"B","Earth","Australia",,4.153
+2013,"B","Earth","Europe",,6.338
+2013,"B","Mars","Dawes",,8.76
+2013,"B","Mars","Herschel I",,8.521
+2013,"B","Mars","Madler",,10.5
+2013,"B","Venus","Aphrodite Terra",,3.147
+2013,"B","Venus","Ishtar Terra",,3.358
+2014,"A","Earth","Africa",,6.999
+2014,"A","Earth","America",,4.621
+2014,"A","Earth","Asia",,9.501
+2014,"A","Earth","Australia",,5.731
+2014,"A","Earth","Europe",,5.069
+2014,"A","Mars","Dawes",,6.224
+2014,"A","Mars","Herschel I",,11.624
+2014,"A","Mars","Madler",,2.077
+2014,"A","Venus","Aphrodite Terra",,2.039
+2014,"A","Venus","Ishtar Terra",,7.416
+2014,"B","Earth","Africa",,1.866
+2014,"B","Earth","America",,7.809
+2014,"B","Earth","Asia",,9.005
+2014,"B","Earth","Australia",,4.397
+2014,"B","Earth","Europe",,5.378
+2014,"B","Mars","Dawes",,9.523
+2014,"B","Mars","Herschel I",,5.536
+2014,"B","Mars","Madler",,5.931
+2014,"B","Venus","Aphrodite Terra",,9.507
+2014,"B","Venus","Ishtar Terra",,12.92
+2015,"A","Earth","Africa",,-0.167
+2015,"A","Earth","America",,8.651
+2015,"A","Earth","Asia",,2.681
+2015,"A","Earth","Australia",,8.909
+2015,"A","Earth","Europe",,7.646
+2015,"A","Mars","Dawes",,7.856
+2015,"A","Mars","Herschel I",,5.392
+2015,"A","Mars","Madler",,3.628
+2015,"A","Venus","Aphrodite Terra",,11.043
+2015,"A","Venus","Ishtar Terra",,5.872
+2015,"B","Earth","Africa",,1.403
+2015,"B","Earth","America",,9.855
+2015,"B","Earth","Asia",,11.529
+2015,"B","Earth","Australia",,1.559
+2015,"B","Earth","Europe",,9.566
+2015,"B","Mars","Dawes",,9.171
+2015,"B","Mars","Herschel I",,4.25
+2015,"B","Mars","Madler",,4.41
+2015,"B","Venus","Aphrodite Terra",,3.938
+2015,"B","Venus","Ishtar Terra",,7.894
+2016,"A","Earth","Africa",,4.37
+2016,"A","Earth","America",,8.253
+2016,"A","Earth","Asia",,6.312
+2016,"A","Earth","Australia",,8.027
+2016,"A","Earth","Europe",,4.724
+2016,"A","Mars","Dawes",,5.042
+2016,"A","Mars","Herschel I",,2.387
+2016,"A","Mars","Madler",,8.156
+2016,"A","Venus","Aphrodite Terra",,13.576
+2016,"A","Venus","Ishtar Terra",,9.825
+2016,"B","Earth","Africa",,3.331
+2016,"B","Earth","America",,9.208
+2016,"B","Earth","Asia",,6.573
+2016,"B","Earth","Australia",,9.633
+2016,"B","Earth","Europe",,7.644
+2016,"B","Mars","Dawes",,7.244
+2016,"B","Mars","Herschel I",,2.569
+2016,"B","Mars","Madler",,4.466
+2016,"B","Venus","Aphrodite Terra",,8.887
+2016,"B","Venus","Ishtar Terra",,0.668

--- a/scripts/demo14.R
+++ b/scripts/demo14.R
@@ -1,0 +1,51 @@
+# A redo of the planet fruit test data
+
+library(dplyr)
+library(tidyr)
+
+years <- 2010:2016
+grades <- c("A", "B")
+planets <- c("Earth", "Mercury", "Venus")
+fruits <- c("Apples", "Lemons", "Oranges")
+
+
+
+continents <- c("Earth.America", "Earth.Asia", "Earth.Africa", "Earth.Australia",
+                "Earth.Europe", "Mars.Dawes", "Mars.Madler", "Mars.Herschel I",
+                "Venus.Ishtar Terra", "Venus.Aphrodite Terra")
+
+combos <- expand.grid(Year = years, Grade = grades, PC = continents, Fruit = fruits)
+
+all <- separate(combos, PC, c("Planet", "Continent"), sep = "\\.")
+
+set.seed(17)
+all$Value <- rnorm(nrow(all), 5, 5) + as.numeric(as.factor(all$Planet))
+
+
+all0 <- filter(all, FALSE)
+
+groups <- c("Year", "Planet")
+
+summarise_combo <- function(groups, alldat) {
+  
+  if(!("Year" %in% groups))  groups <- c("Year", groups)
+  
+  alldat %>%
+    dplyr::group_by_(.dots = groups) %>%
+    dplyr::summarise(Value = round(mean(Value),3)) %>%
+    dplyr::ungroup()
+}
+
+
+combos <- list("Year","Grade", "Planet", "Fruit", 
+               c("Grade", "Planet"),
+               c("Planet", "Continent"),
+               c("Grade", "Planet", "Continent"))
+
+combos_data <- lapply(combos, summarise_combo, alldat = all)
+
+combos_data_cols <- lapply(combos_data, function(x) full_join(all0, x))
+
+final <- do.call("bind_rows", combos_data_cols)
+
+write.csv(final, file = "data/indicator_14-1-1.csv", row.names = FALSE, na = "")

--- a/scripts/metadatacheck.py
+++ b/scripts/metadatacheck.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu May  4 13:53:01 2017
+
+@author: dougashton
+"""
+
+#%% setup
+
+import yaml
+
+status = True
+
+#%% Checkinga single item 
+def check_meta(meta):
+    """Check an individual metadata and return logical status"""
+    print(meta["sdg_goal"])
+    return True
+
+#%% Find all items
+
+import glob
+metas = glob.glob("_indicators/*.md")
+    
+#%% Get the yaml from the front matter
+
+for met in metas:
+    print(met)
+    with open(met) as stream:
+        meta = next(yaml.load_all(stream))
+    status = status & check_meta(meta)
+
+#%%
+
+print(status)


### PR DESCRIPTION
- Adds a continent category which is a child of planet
- Add `data_edge_list` to meta data, which is a string specifying a parent child edge list `"P1:C1,P2,C2,..."`

Parents are children are listed by their column index (counting from 0). So for the demo data set this is `2:3` which indicates that column 2 (Planet) is the parent of 3 (Continent)