### PR TITLE
Data source and other chart mods

### DIFF
--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -6,7 +6,6 @@
 
     {% assign graph_template = 'components/charts/' | append: graph_type | append: '.html' %}
 
-    <h4>{{ include.graph_title }}</h4>
     <div class="plot-container">
         {% include {{graph_template}} data=include.data %}
     </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -40,7 +40,8 @@ $(function() {
         country: $('#indicatorData').data('country'),
         indicatorId: $('#indicatorData').data('indicatorid'),
         chartTitle: $('#indicatorData').data('charttitle'),
-        measurementUnit: $('#indicatorData').data('measurementunit')
+        measurementUnit: $('#indicatorData').data('measurementunit'),
+        dataSource: $('#indicatorData').data('datasource')
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData'

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -41,7 +41,8 @@ $(function() {
         indicatorId: $('#indicatorData').data('indicatorid'),
         chartTitle: $('#indicatorData').data('charttitle'),
         measurementUnit: $('#indicatorData').data('measurementunit'),
-        dataSource: $('#indicatorData').data('datasource')
+        dataSource: $('#indicatorData').data('datasource'),
+        geographicalArea: $('#indicatorData').data('geographicalarea')
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData'

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -38,7 +38,8 @@ $(function() {
       var model = new indicatorModel({
         data: $('#indicatorData').data('indicatordata'),
         country: $('#indicatorData').data('country'),
-        indicatorId: $('#indicatorData').data('indicatorid')
+        indicatorId: $('#indicatorData').data('indicatorid'),
+        chartTitle: $('#indicatorData').data('charttitle')
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData'

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -39,7 +39,8 @@ $(function() {
         data: $('#indicatorData').data('indicatordata'),
         country: $('#indicatorData').data('country'),
         indicatorId: $('#indicatorData').data('indicatorid'),
-        chartTitle: $('#indicatorData').data('charttitle')
+        chartTitle: $('#indicatorData').data('charttitle'),
+        measurementUnit: $('#indicatorData').data('measurementunit')
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData'

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -37,7 +37,7 @@
   {{ page.content }}
 
   <section id="indicatorData" data-indicatordata='{{json_data}}' data-indicatorid='{{dataset_name}}' data-country="{{ site.country.name }}"
-    data-charttitle="{{ page.actual_indicator_available }}" data-measurementunit="{{ page.computation_units }}">
+    data-charttitle="{{ page.actual_indicator_available }}" data-measurementunit="{{ page.computation_units }}" data-datasource="{{ page.source_organisation_1 }}">
     {% include components/charts/chart.html graph_type=page.graph data=json_data %}
 
     <div class="alert alert-warning" role="alert">

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -37,7 +37,7 @@
   {{ page.content }}
 
   <section id="indicatorData" data-indicatordata='{{json_data}}' data-indicatorid='{{dataset_name}}' data-country="{{ site.country.name }}"
-    data-charttitle="{{ page.actual_indicator_available }}" data-measurementunit="{{ page.computation_units }}" data-datasource="{{ page.source_organisation_1 }}">
+    data-charttitle="{{ page.actual_indicator_available }}" data-measurementunit="{{ page.computation_units }}" data-datasource="{{ page.source_organisation_1 }}" data-geographicalarea="{{ page.national_geographical_coverage }}">
     {% include components/charts/chart.html graph_type=page.graph data=json_data %}
 
     <div class="alert alert-warning" role="alert">

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -37,7 +37,7 @@
   {{ page.content }}
 
   <section id="indicatorData" data-indicatordata='{{json_data}}' data-indicatorid='{{dataset_name}}' data-country="{{ site.country.name }}"
-    data-charttitle="{{ page.actual_indicator_available }}">
+    data-charttitle="{{ page.actual_indicator_available }}" data-measurementunit="{{ page.computation_units }}">
     {% include components/charts/chart.html graph_type=page.graph data=json_data %}
 
     <div class="alert alert-warning" role="alert">

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -23,16 +23,22 @@
 
 <div id="main-content" class="container goal-{{page.sdg_goal}}">
 
-  {% capture goal_href %}{{ goal_uri }}{% endcapture %} {% capture goal_number %}{{ goal.goal }}{% endcapture %} {% capture
-  goal_title %}{{ goal.title }}{% endcapture %} {% capture indicator_title %}{{ page.title }}{% endcapture %} {% include
-  components/breadcrumb.html %}
+  {% capture goal_href %}{{ goal_uri }}{% endcapture %} 
+  {% capture goal_number %}{{ goal.goal }}{% endcapture %} 
+  {% capture goal_title %}{{ goal.title }}{% endcapture %} 
+  {% capture indicator_title %}{{ page.title }}{% endcapture %} 
 
-  {% capture dataset_name %}indicator_{{page.indicator | slugify }}{% endcapture %} {% assign sdg_indicator_data = site.data[dataset_name]
-  %} {% assign indicator_metadata = sdg_indicators | where: "indicator_id", page.indicator | first %} {% assign json_data
-  = sdg_indicator_data | jsonify %} {{ page.content }}
+  {% capture dataset_name %}indicator_{{page.indicator | slugify }}{% endcapture %} 
+  {% assign sdg_indicator_data = site.data[dataset_name] %} 
+  {% assign indicator_metadata = sdg_indicators | where: "indicator_id", page.indicator | first %} 
+  {% assign json_data = sdg_indicator_data | jsonify %} 
+  
+  {% include components/breadcrumb.html %}
+  {{ page.content }}
 
-  <section id="indicatorData" data-indicatordata='{{json_data}}' data-indicatorid='{{dataset_name}}' data-country="{{ site.country.name }}">
-    {% include components/charts/chart.html graph_type=page.graph data=json_data chart_title=page.graph_title %}
+  <section id="indicatorData" data-indicatordata='{{json_data}}' data-indicatorid='{{dataset_name}}' data-country="{{ site.country.name }}"
+    data-charttitle="{{ page.actual_indicator_available }}">
+    {% include components/charts/chart.html graph_type=page.graph data=json_data %}
 
     <div class="alert alert-warning" role="alert">
       <i class="fa fa-info" aria-hidden="true"></i> See metadata tab for sources, definitions, and methodology information

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -6,6 +6,7 @@ var indicatorModel = function (options) {
   this.indicatorId = options.indicatorId;
   this.chartTitle = options.chartTitle;
   this.measurementUnit = options.measurementUnit;
+  this.dataSource = options.dataSource;
   this.selectedFields = [];
 
   this.onDataComplete = new event(this);

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -5,6 +5,7 @@ var indicatorModel = function (options) {
   this.country = options.country;
   this.indicatorId = options.indicatorId;
   this.chartTitle = options.chartTitle;
+  this.measurementUnit = options.measurementUnit;
   this.selectedFields = [];
 
   this.onDataComplete = new event(this);

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -7,6 +7,7 @@ var indicatorModel = function (options) {
   this.chartTitle = options.chartTitle;
   this.measurementUnit = options.measurementUnit;
   this.dataSource = options.dataSource;
+  this.geographicalArea = options.geographicalArea;
   this.selectedFields = [];
 
   this.onDataComplete = new event(this);

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -4,6 +4,7 @@ var indicatorModel = function (options) {
   this.data = options.data;
   this.country = options.country;
   this.indicatorId = options.indicatorId;
+  this.chartTitle = options.chartTitle;
   this.selectedFields = [];
 
   this.onDataComplete = new event(this);

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -73,6 +73,10 @@ var indicatorView = function (model, options) {
           yAxes: [{
             ticks: {
               suggestedMin: 0
+            },
+            scaleLabel: {
+              display: this._model.measurementUnit,
+              labelString: this._model.measurementUnit
             }
           }]
         },

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -78,7 +78,16 @@ var indicatorView = function (model, options) {
         },
         legend: {
           display: true,
-          usePointStyle: true
+          usePointStyle: true,
+          position: 'bottom',
+          padding: 20
+        },
+        title: {
+          fontSize: 18,
+          fontStyle: 'normal',
+          display: this._model.chartTitle,
+          text: this._model.chartTitle,
+          padding: 20
         }
       }
     });

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -84,7 +84,7 @@ var indicatorView = function (model, options) {
         },
         layout: {
           padding: {
-            bottom: 40
+            bottom: 55
           }
         },
         legend: {
@@ -106,6 +106,16 @@ var indicatorView = function (model, options) {
     Chart.pluginService.register({
       afterDatasetsDraw: function(chart) {
         var $canvas = $(that._rootElement).find('canvas');
+
+        var textOutputs = [
+          'Source: ' + (that._model.dataSource ? that._model.dataSource : ''),
+          'Geographical Area: ' + (that._model.geographicalArea ? that._model.geographicalArea : '')
+        ];
+
+        var textRowHeight = 20;
+        var x = $canvas.width();
+        var y = $canvas.height() - 40 - (textOutputs.length * textOutputs.length);
+
         var canvas = $canvas.get(0);
         var ctx = canvas.getContext("2d");
 
@@ -113,8 +123,12 @@ var indicatorView = function (model, options) {
         ctx.textBaseline = 'middle';
         ctx.font = '14px Arial';
         ctx.fillStyle = '#6e6e6e';
-        ctx.fillText('Source: ' + (that._model.dataSource ? that._model.dataSource : ''), $canvas.width(), $canvas.height() - 15);
-      }
+
+        _.each(textOutputs, function(textOutput) {
+          ctx.fillText(textOutput, x, y);
+          y += textRowHeight;
+        });
+       }
     });
   };
 

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -90,6 +90,7 @@ var indicatorView = function (model, options) {
         },
         layout: {
           padding: {
+            top: 20,
             bottom: 55
           }
         },

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -57,6 +57,8 @@ var indicatorView = function (model, options) {
     if (this._chartInstance) {
       this._chartInstance.destroy();
     }
+    
+    var that = this;
 
     this._chartInstance = new Chart($(this._rootElement).find('canvas'), {
       type: 'line',
@@ -80,6 +82,11 @@ var indicatorView = function (model, options) {
             }
           }]
         },
+        layout: {
+          padding: {
+            bottom: 40
+          }
+        },
         legend: {
           display: true,
           usePointStyle: true,
@@ -93,6 +100,20 @@ var indicatorView = function (model, options) {
           text: this._model.chartTitle,
           padding: 20
         }
+      }
+    });
+
+    Chart.pluginService.register({
+      afterDatasetsDraw: function(chart) {
+        var $canvas = $(that._rootElement).find('canvas');
+        var canvas = $canvas.get(0);
+        var ctx = canvas.getContext("2d");
+
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        ctx.font = '14px Arial';
+        ctx.fillStyle = '#6e6e6e';
+        ctx.fillText('Source: ' + (that._model.dataSource ? that._model.dataSource : ''), $canvas.width(), $canvas.height() - 15);
       }
     });
   };

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -11,7 +11,12 @@ var indicatorView = function (model, options) {
   this._rootElement = options.rootElement;
 
   this._model.onDataComplete.attach(function (sender, args) {
-    view_obj.createPlot(args);
+    if(!view_obj._chartInstance) {
+      view_obj.createPlot(args);
+    } else {
+      view_obj.updatePlot(args);
+    }
+    
     view_obj.createTables(args);
   });
 
@@ -52,11 +57,12 @@ var indicatorView = function (model, options) {
     });
   };
 
-  this.createPlot = function (chartInfo) {
+  this.updatePlot = function(chartInfo) {
+    view_obj._chartInstance.data.datasets = chartInfo.datasets;
+    view_obj._chartInstance.update(1000, true);
+  };
 
-    if (this._chartInstance) {
-      this._chartInstance.destroy();
-    }
+  this.createPlot = function (chartInfo) {
     
     var that = this;
 
@@ -104,7 +110,7 @@ var indicatorView = function (model, options) {
     });
 
     Chart.pluginService.register({
-      afterDatasetsDraw: function(chart) {
+      afterDraw: function(chart) {
         var $canvas = $(that._rootElement).find('canvas');
 
         var textOutputs = [


### PR DESCRIPTION
This implements the changes required for #112. If no source is found, then 'Source: ' is still shown on the graph, as can be seen on this [ONS graph](https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms). I do a similar thing for 'Geographical area'. Both are at the bottom right of the graph.

I moved the legend to the bottom of the graph, which is more in keeping with the example given above, and doesn't clutter the title area.

The y axis label is not oriented horizontally - in some cases, such as 'percentage' a horizontal orientation would result in an unnecessarily narrow graph, so I went with the default orientation.

On a technical note, I've added more data-* attributes to the #indicatorData element, and although this is fine, I may refactor at some point, maybe to get some of this information directly from JSON.

I also noticed that some of `indicator.html`'s Jekyll tag formatting had become a bit messed up, so I reintroduced some newlines.

Overall, I suspect there may be some tweaks required, but they shouldn't take long to resolve.

![image](https://cloud.githubusercontent.com/assets/2493614/26023610/3c404f88-37b8-11e7-99f8-b74efb69578f.png)

