### PR TITLE
Negative numbers not discarded by rounding function

### DIFF
--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -11,7 +11,7 @@ var indicatorModel = function (options) {
   this.selectedFields = [];
 
   this.roundingFunc = options.roundingFunc || function(value) {
-    var to = 3, mult = Math.pow(10, to - Math.floor(Math.log(value) / Math.LN10) - 1);
+    var to = 3, mult = Math.pow(10, to - Math.floor(Math.log(Math.abs(value)) / Math.LN10) - 1);
     return Math.round(value * mult) / mult;
   };
 


### PR DESCRIPTION
The rounding function discarded negative numbers by converting them to NaN.

A `Math.abs(...)` call resolves the issue.