### PR TITLE
Home page row cycles fix 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "jekyll", "3.3.1"
+gem "jekyll", "3.5.1"
 gem "html-proofer"

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -8,11 +8,11 @@
     {% assign sdg_goals = site.data.sdg_goals %}
 
     {% for goal in sdg_goals %}
-        {% cycle 'add row' : '<div class="row no-gutters">', nil, nil, nil, nil, nil %}
+        {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
             <div class="col-xs-4 col-md-2">
                 <a href="./{{ goal.short | slugify }}/"><img src="{{ site.baseurl }}/assets/img/goals/{{ goal.goal }}.png" id="goal-{{ goal.goal }}" alt="icon for Goal {{ goal.goal }} - {{ goal.title }}" /></a>
             </div>
-        {% cycle 'end row' : nil, nil, nil, nil, nil, '</div>' %}
+        {% cycle 'end row' : '', '', '', '', '', '</div>' %}
     {% endfor %}
         <div class="col-xs-4 col-md-2">
             <img src="{{ site.baseurl }}/assets/img/goals/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -35,11 +35,11 @@
 
   {% assign indicators = site.data.sdg_indicator_metadata | where:'goal', page.sdg_goal %}
   {% for indicator in indicators %}
-    {% cycle 'add row' : '<div class="indicator-cards row no-gutters">', nil, nil, nil %}
+    {% cycle 'add row' : '<div class="indicator-cards row no-gutters">', '', '', '' %}
         <div class="col-md-6 col-lg-3">
             <a href="{{ site.baseurl }}/{{ indicator.indicator_id | replace: '.', '-' }}"><span>{{ indicator.indicator_id }}</span> {{ indicator.indicator }}</a>
         </div>
-    {% cycle 'end row' : nil, nil, nil, '</div>' %}
+    {% cycle 'end row' : '', '', '', '</div>' %}
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
This fixes #281.

[GitHub updated their version of Jekyll to 3.5.1](https://pages.github.com/versions/) on Tuesday, 8th August.

This caused an issue with the `cycle` liquid tag, and the issue can be reproduced locally by updating `Gemfile` jekyll version to 3.5.1 and running `bundle update` from the command line.

To fix the issue, I changed the `nil` parameters in the `cycle` tag to empty strings.
