### PR TITLE
Responsive menu/search

### DIFF
--- a/_includes/components/dev-disclaimer.html
+++ b/_includes/components/dev-disclaimer.html
@@ -1,5 +1,6 @@
 <div class="container">
-<div class="alert alert-danger" role="alert">
-<strong class="phase-tag">Alpha</strong> This is a development website and data may be test data. We welcome your <a href="mailto:sustainabledevelopment@ons.gov.uk">feedback</a>.
-</div>
+  <div class="alert alert-danger" role="alert">
+    <strong class="phase-tag">Alpha</strong> This is a development website and data may be test data. We welcome your
+    <a href="mailto:sustainabledevelopment@ons.gov.uk">feedback</a>.
+  </div>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,8 +13,8 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li><a href="#" data-target="menu">Menu</a></li>
-        <li><a href="#" data-target="search">Search</a></li>
+        <li><a href="javascript:void(0)" data-target="menu">Menu</a></li>
+        <li><a href="javascript:void(0)" data-target="search">Search</a></li>
       </ul>
 
       <ul class="nav navbar-nav menu-target" id="menu">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,41 +1,39 @@
 <a class="sr-only sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">Skip to main content</a>
-<header role="banner">
-<nav class="navbar navbar-default navbar-fixed-top" id="main-nav">
-  <div id="disclaimer">
+<div id="disclaimer">
   {% include components/dev-disclaimer.html %}
-  </div>
-<div class="container">
-  <div>
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="{{ site.baseurl }}/" id="home">
-        <img src="{{ site.baseurl }}/assets/img/SDG_logo.png" alt="Sustainable Development Goals Logo" />
-      </a>
-    </div>
-    <div class="collapse navbar-collapse" id="navbar">
-      <ul class="nav navbar-nav navbar-right">
-        <li {% if page.permalink contains "/reporting-status/" or page.permalink contains "/news" or page.layout == "post" %}class="nav-link"{% else %}class="nav-link active"{% endif %}>
-            <a href="{{ site.baseurl }}/">Goals</a>
-          </li>
-          <li {% if page.permalink == "/reporting-status/" %}class="nav-link active"{% else %}class="nav-link"{% endif %}>
-            <a href="{{ site.baseurl }}/reporting-status">Reporting Status</a>
-          </li>
-          <li {% if page.permalink contains "/news" or page.layout == "post" %}class="nav-link active"{% else %}class="nav-link"{% endif %}>
-            <a href="{{ site.baseurl }}/news">News &amp; Events</a>
-          </li>
+</div>
+
+<header role="banner">
+  <div class="container">
+
+    <a class="navbar-brand" href="{{ site.baseurl }}/" id="home">
+      <img src="{{ site.baseurl }}/assets/img/SDG_logo.png" alt="Sustainable Development Goals Logo" />
+    </a>
+
+    <nav class="navbar navbar-default" id="main-nav">
+
+      <ul class="top-level">
+        <li><a href="#" data-target="menu">Menu</a></li>
+        <li><a href="#" data-target="search">Search</a></li>
       </ul>
-    </div>
 
-    {% include search.html %}
+      <ul class="nav navbar-nav menu-target" id="menu">
+        <li {% if page.permalink contains "/reporting-status/" or page.permalink contains "/news" or page.layout=="post" %}class="nav-link"
+          {% else %}class="nav-link active" {% endif %}>
+          <a href="{{ site.baseurl }}/">Goals</a>
+        </li>
+        <li {% if page.permalink=="/reporting-status/" %}class="nav-link active" {% else %}class="nav-link" {% endif %}>
+          <a href="{{ site.baseurl }}/reporting-status">Reporting Status</a>
+        </li>
+        <li {% if page.permalink contains "/news" or page.layout=="post" %}class="nav-link active" {% else %}class="nav-link" {%
+          endif %}>
+          <a href="{{ site.baseurl }}/news">News &amp; Events</a>
+        </li>
+      </ul>
 
+      {% include search.html %} 
+
+    </nav>
   </div>
 
-  </div>
-</nav>
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<a class="sr-only sr-only-focusable" href="#main-content">Skip to main content</a>
+<a class="sr-only sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">Skip to main content</a>
 <header role="banner">
 <nav class="navbar navbar-default navbar-fixed-top" id="main-nav">
   <div id="disclaimer">

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,4 +1,4 @@
-<div id="search">
+<div id="search" class="menu-target">
   <label for="indicator_search">
     <i class="fa fa-search" aria-hidden="true"></i>
   </label>

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -299,6 +299,7 @@ header {
 
       input { 
         width: 100%;
+        color: #333;
 
         &:focus {
           width: 100%;

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -242,6 +242,22 @@ h5 + .btn-download {
   }
 }
 
+#skiplink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10000;
+  width: 250px;
+  left: 50%;
+  margin-left: -125px;
+  padding: 10px;
+  background: white;
+  text-align: center;
+  border: 1px solid black;
+  color: black;
+  display: block;
+}
+
 .heading {
   a {
     background: transparent;

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -8,6 +8,7 @@ $vanilla: #fff;
 $footer-color : #E5E6E7;
 $goal-colors : #E5243B #DDA63A #4C9F38 #C5192D #FF3A21 #26BDE2 #FCC30B #A21942 #FD6925 #DD1367 #FD9D24 #BF8B2E #3F7E44 #0A97D9 #56C02B #00689D #19486A;
 $navbar-height : 175;
+$disclaimer-height: 40;
 $collapsed-navbar-height: $navbar-height - 30;
 @mixin noselect {
   user-select: none;
@@ -35,7 +36,7 @@ $collapsed-navbar-height: $navbar-height - 30;
 
 body {
   background: $main-background-color; // url('../img/SDG Wheel_Transparent-01.png') bottom 50px right -300px no-repeat;
-  padding: $navbar-height + unquote("px") 0 0 0;
+  padding: $disclaimer-height + unquote("px") 0 0 0;
   margin: 0;
 }
 
@@ -45,23 +46,6 @@ header {
     .navbar-default {
       border: none;
     }
-  }
-}
-
-#search {
-  float: right;
-  position: relative;
-
-  label {
-    position: absolute;
-    top: 3px;
-    left: 7px;
-    font-size: 20px;
-  }
-
-  input {
-    padding: 5px;
-    padding-left: 29px;
   }
 }
 
@@ -104,33 +88,27 @@ header {
   }
 }
 
-#main-nav {
-  li {
-    text-transform: uppercase;
-  }
-  -webkit-transition: all .35s;
-  -moz-transition: all .35s;
-  transition: all .35s;
-  border: none;
-  height: $navbar-height+unquote("px");
-
-  // @media only screen and (max-width: 990px) {
-  //   height: 155px;
-  // }
-
-  background: white url(../img/sdgbg.png) bottom left repeat-x;
-  #disclaimer {
+#disclaimer {
     background: #f2dede;
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 400;
+
     .phase-tag {
       background: #005ea5;
       color: white;
       text-transform: uppercase;
       padding: 2px 5px 0;
     }
+    .alert {
+      margin-bottom: 0;
+      padding: 10px;
+    }
     .alert-danger {
       border: none;
       margin-bottom: 0;
-      padding-left: 0;
       a {
         text-decoration: underline;
       }
@@ -140,45 +118,196 @@ header {
       }
     }
   }
-  .navbar-brand img {
-    //height: $navbar-height - 35 + unquote("px");
-    -webkit-transition: all .35s;
-    -moz-transition: all .35s;
-    transition: all .35s;
-    max-width: 390px;
 
-    /* Extra Small Devices, Phones */
-    @media only screen and (max-width: 480px) {
-      max-width: 225px;
-    }
-
-    @media only screen and (max-width: 990px) {
-      max-width: 280px;
-    }
+//  background: white url(../img/sdgbg.png) bottom left repeat-x;
+.navbar-brand {
+  display: block;
+  img {
+    width: 300px;
   }
-  ul.nav {
+}
+
+
+
+.navbar {
+
+  li {
+    text-transform: uppercase;
+  }
+
+  ul.navbar-nav {
+    float: right;
     margin-top: 12px;
+
     li {
       a {
-        background: none;
         padding: 2px;
         margin: 2px 15px;
+        //color: #E5E6E7;
+        //background: #414042;
+
+        &:hover {
+          //background: #414042;
+          //color: #E5E6E7;
+        }
       }
-      &.active {
+
+      &.active a {
+        //color: #E5E6E7;
+        //background: #58595B;
+        border-bottom: 2px solid #333;
+        background: transparent;
+
+        &:hover {
+          //background: #58595B;
+          //color: #E5E6E7;
+          background: transparent;
+        }
+      }
+
+      a:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  &.navbar-default {
+    background: transparent;
+    border: none;
+  }
+
+  .top-level {
+    display: none;
+  }
+
+  #search {
+    position: relative;
+    clear: left;
+    float: right;
+
+    label {
+      position: absolute;
+      top: 3px;
+      left: 7px;
+      font-size: 20px;
+    }
+
+    input {
+      padding: 5px;
+      padding-left: 29px;
+      width: 140px;
+      transition: width 0.4s;
+
+      &:focus {
+        width: 200px;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 768px) {
+
+  header .container {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .navbar-brand {
+    height: auto;
+  }
+
+  .navbar {
+    clear: left; 
+
+    &.navbar-default {
+      color: #E5E6E7;
+      background: #414042;
+      margin-bottom: 10px;
+    }
+
+    .top-level {
+      display: block;
+      font-size: 16px;
+      
+      li {
+        float: left;
+        width: 50%;
+        padding: 15px;
+
+        &.active {
+          background: #58595B;
+        }
+
         a {
-          color: #333;
-          border-bottom: 2px solid #333;
+          color: #E5E6E7;
+          display: block;
+        }
+      }
+    }
+
+    & .menu-target {
+      background: #58595B;
+    }
+
+    ul.navbar-nav {
+      float: none;
+      display: none;
+      clear: left;
+      margin: 0;
+
+      font-size: 15px;
+
+      li {
+
+        a {
+          display: block;
+          background: #58595B;
+          padding: 6px 0 6px;
+          color: #E5E6E7;
+
+          &:hover {
+            color: #E5E6E7;
+          }
+        }
+
+        &.active a {
+          border: none;
+          color: #fff;
+          font-weight: bold;
+
+          &:hover {
+            color: #fff;
+          }
+        }
+
+        &:last-child {
+          padding-bottom: 10px;
+        }
+      }
+    }
+
+    #search {
+      display: none;
+      width: 100%;
+      padding: 20px;
+
+      label {
+        top: 23px;
+        left: 25px;
+        color: black;
+      }
+
+      input { 
+        width: 100%;
+
+        &:focus {
+          width: 100%;
         }
       }
     }
   }
-  &.collapsed {
-    height: $collapsed-navbar-height + unquote("px");
-    .navbar-brand img {
-      height: $navbar-height - 120 + unquote("px");
-    }
-  }
 }
+
 
 h1,
 h2,

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,0 +1,56 @@
+$(function() {
+
+  var topLevelSearchLink = $('.top-level a:eq(1)');
+
+  var resetForSmallerViewport = function() {
+    topLevelSearchLink.text('Search');
+    $('.top-level li').removeClass('active');
+    $('.top-level a').removeClass('open');
+  };  
+
+  $('.top-level a').click(function() {
+    var target = $(this).data('target');
+
+    $('.top-level li').removeClass('active');
+    topLevelSearchLink.text('Search');
+
+    var targetEl = $('#' + target);
+    var wasVisible = targetEl.is(':visible');
+
+    // hide everything:
+    $('.menu-target').hide();
+
+    if(target === 'search') {
+      $(this).toggleClass('open');
+      
+      if($(this).hasClass('open') || !wasVisible) {
+        $(this).text('Hide');
+      } else {
+        $(this).text('Search');
+      }
+    }
+
+    if(!wasVisible) {
+      targetEl.show();
+      $(this).parent().addClass('active');
+    }
+  });
+
+  $(window).on('resize', function(e) {
+    var viewportWidth = window.innerWidth,
+        previousWidth = $('body').data('vwidth'),
+        breakpointWidth = 768;
+
+    if(viewportWidth > breakpointWidth && previousWidth <= breakpointWidth) {
+      // switched to larger viewport:
+      $('.menu-target').show();
+    } else if(previousWidth >= breakpointWidth && viewportWidth < breakpointWidth) {
+      // switched to smaller viewport:
+      $('.menu-target').hide();
+      resetForSmallerViewport();
+    }
+
+    // update the viewport width:
+    $('body').data('vwidth', viewportWidth);
+  });
+});

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -11,3 +11,4 @@
 {% include_relative indicatorController.js %}
 {% include_relative search.js %}
 {% include_relative reportingStatus.js %}
+{% include_relative menu.js %}


### PR DESCRIPTION
This fixes #291 as well as vastly improving the 'skip to content' accessibility link.

1 - The 'Skip to main content' link is now much more prominently displayed.
2 - As shown in #291, the menu/search was broken in lower viewports. This PR fixes those issues, and is visually very similar to that of the main [ONS site](https://www.ons.gov.uk/). Gone is the fixed header that reduces in height as the user scrolls down, but I think that this wasn't really needed, and the larger header height was regarded as too large by some anyway.