### PR TITLE
Reporting status now responds to viewport width changes

### DIFF
--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -3,6 +3,7 @@
 <div id="main-content" class="container reportingstatus" data-url="{{ site.baseurl }}/indicators.json">
 
   <h2>Reporting Status</h2>
+  
   {% assign sdg_goals = site.data.sdg_goals %}
     <!--<ul style="list-style-type: decimal; margin-left: 50px;margin-bottom: 30px;margin-top:30px;">-->
       {% for goal in sdg_goals %}
@@ -17,9 +18,16 @@
             <h3 class="status-goal"><a href="{{ site.baseurl }}/{{ goal.short | slugify }}/">{{ goal.short }}</a></h3>
             <div class="summary">
               <div class="statuses">
-                <span class="status danger"></span><strong>Exploring data sources</strong><span class="value"></span>
-                <span class="status warning"></span><strong>Statistics in progress</strong><span class="value"></span>
-                <span class="status success"></span><strong>Reported online</strong><span class="value"></span>
+                <div>
+                  <span class="status danger"></span><strong>Exploring data sources</strong><span class="value"></span>
+                </div>
+                <div>
+                  <span class="status warning"></span><strong>Statistics in progress</strong><span class="value"></span>
+                </div>
+                <div>
+                  <span class="status success"></span><strong>Reported online</strong><span class="value"></span>
+                </div>
+                <br style="clear:both;" />
               </div>
             </div>
             <div class="goal-stats">

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -685,6 +685,8 @@ h5 + .btn-download {
       }
     }
   }
+
+  
   .danger {
     background-color: #d9534f;
   }
@@ -695,23 +697,23 @@ h5 + .btn-download {
     background-color: #5cb85c;
   }
   .statuses {
-    line-height: 30px;
-    height: 30px;
-    padding-left: 5px;
-    display: none;
-  }
-  .status {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    display: inline-block;
-    margin-right: 3px;
-    &:not(:first-child) {
-      margin-left: 10px;
+
+    strong {
+      font-weight: normal;
     }
-  }
-  .status-goal {
-    display: none;
+    > div {
+      display: inline-block;
+
+      margin-right: 10px;
+
+      .status {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        display: inline-block;
+        margin-right: 3px;
+      }
+    }
   }
   .value {
     color: #777;
@@ -728,28 +730,32 @@ h5 + .btn-download {
   }
   .divider {
     height: 15px;
-    display: none;
   }
   .goal {
     clear: left;
-    border: 1px solid #efefef;
     margin-bottom: 4px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #ccc;
   }
   .frame {
-    width: 0;
+    width: 115px;
     float: left;
     min-height: 1px;
   }
   .details {
-    width: 100%;
+    width: calc(100% - 125px);
     float: left;
     h3 {
       margin-top: 10px;
+      @media only screen and (max-width: 720px) {
+        margin-top: 3px;
+      }
+      @media only screen and (max-width: 520px) {
+        margin-bottom: 3px;
+      }
     }
   }
-  .frame img {
-    display: none;
-  }
+
   #back-to-top {
     cursor: pointer;
     position: fixed;

--- a/assets/js/reportingStatus.js
+++ b/assets/js/reportingStatus.js
@@ -79,24 +79,24 @@ $(function() {
         });        
       });
 
-      // animation:
-      if($('#main-content').hasClass('reportingstatus')) {
-        setTimeout(function() {
+      // // animation:
+      // if($('#main-content').hasClass('reportingstatus')) {
+      //   setTimeout(function() {
 
-          var width = $('.reportingstatus').width();
+      //     var width = $('.reportingstatus').width();
 
-          $('#main-content').find('.statuses, .divider, h3').slideDown(function() {
-            $('.frame').animate({ 'width' : '110px', duration: 1500, queue: false }, function() {
-              $('.goal img').fadeIn(1500, function() {
-                $('.goal').animate({ borderTopColor: '#ddd', borderLeftColor: '#ddd', borderRightColor: '#ddd', borderBottomColor: '#ddd' }, 500);
-              });
-            });
+      //     $('#main-content').find('.statuses, .divider, h3').slideDown(function() {
+      //       $('.frame').animate({ 'width' : '110px', duration: 1500, queue: false }, function() {
+      //         $('.goal img').fadeIn(1500, function() {
+      //           $('.goal').animate({ borderTopColor: '#ddd', borderLeftColor: '#ddd', borderRightColor: '#ddd', borderBottomColor: '#ddd' }, 500);
+      //         });
+      //       });
 
-            $('.details').animate({ 'width' : width - 130 + 'px', duration: 1500, queue: false });
-          });
+      //       $('.details').animate({ 'width' : width - 130 + 'px', duration: 1500, queue: false });
+      //     });
 
-        }, 1200);
-      }
+      //   }, 1200);
+      // }
     });
 
   }

--- a/assets/js/reportingStatus.js
+++ b/assets/js/reportingStatus.js
@@ -78,26 +78,6 @@ $(function() {
 
         });        
       });
-
-      // // animation:
-      // if($('#main-content').hasClass('reportingstatus')) {
-      //   setTimeout(function() {
-
-      //     var width = $('.reportingstatus').width();
-
-      //     $('#main-content').find('.statuses, .divider, h3').slideDown(function() {
-      //       $('.frame').animate({ 'width' : '110px', duration: 1500, queue: false }, function() {
-      //         $('.goal img').fadeIn(1500, function() {
-      //           $('.goal').animate({ borderTopColor: '#ddd', borderLeftColor: '#ddd', borderRightColor: '#ddd', borderBottomColor: '#ddd' }, 500);
-      //         });
-      //       });
-
-      //       $('.details').animate({ 'width' : width - 130 + 'px', duration: 1500, queue: false });
-      //     });
-
-      //   }, 1200);
-      // }
     });
-
   }
 });


### PR DESCRIPTION
I have removed the animation too - it looked alright when I first did it, but having seen it a few times now, find it a little annoying.

More importantly, the initial viewport width isn't used to set the widths of the elements. CSS `calc(...)` is now used, so it responds to viewport width changes; other tweaks have been made to make things look good at other viewport widths too.
