### PR TITLE
Reporting status works without JavaScript enabled

### DIFF
--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -32,9 +32,9 @@
         </div>
         <div class="goal-stats">
           <!-- please keep this 'funky' markup; it has an impact on the display of the bar components -->
-          <span class="danger" style="width: {{ exploring_count | times: 100 | divided_by: overall_indicator_count }}%"></span
-          ><span class="warning" style="width: {{ in_progress_count | times: 100 | divided_by: overall_indicator_count }}%"></span
-          ><span class="success" style="width: {{ complete_count | times: 100 | divided_by: overall_indicator_count }}%"></span>
+          <span class="danger"></span
+          ><span class="warning"></span
+          ><span class="success"></span>
         </div>
       </div>
     <!--</li>-->
@@ -83,9 +83,9 @@
             </div>
             <div class="goal-stats">
               <!-- please keep this 'funky' markup; it has an impact on the display of the bar components -->
-              <span class="danger" style="width: {{ exploring_count | times: 100 | divided_by: goal_indicator_count }}%"></span
-              ><span class="warning" style="width: {{ in_progress_count | times: 100 | divided_by: goal_indicator_count }}%"></span
-              ><span class="success" style="width: {{ complete_count | times: 100 | divided_by: goal_indicator_count }}%"></span>
+              <span class="danger"></span
+              ><span class="warning"></span
+              ><span class="success"></span>
             </div>
             <div class="divider">
             </div>

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -4,31 +4,37 @@
 
   <h2>Reporting Status</h2>
 
+  {% assign goal_indicators = site.indicators %}
+  {% assign overall_indicator_count = goal_indicators | size %}
+  {% assign exploring_count = goal_indicators | where: 'reporting_status', 'notstarted' | size %}
+  {% assign in_progress_count = goal_indicators | where: 'reporting_status', 'inprogress' | size %}
+  {% assign complete_count = goal_indicators | where: 'reporting_status', 'complete' | size %}
+
   <div class="goal goal-overall" data-goalid="{{ goal.goal }}">
       <div class="details">
         <h3 class="status-goal">
           Overall Reporting Status
-          <span class="total"><span></span> indicators</span> 
+          <span class="total"><span>{{ overall_indicator_count }}</span> indicators</span> 
         </h3>
         <div class="summary">
           <div class="statuses">
             <div>
-              <span class="status danger"></span><strong>Exploring data sources</strong><span class="value"></span>
+              <span class="status danger">{{ exploring_count }}</span><strong>Exploring data sources</strong><span class="value"></span>
             </div>
             <div>
-              <span class="status warning"></span><strong>Statistics in progress</strong><span class="value"></span>
+              <span class="status warning">{{ in_progress_count }}</span><strong>Statistics in progress</strong><span class="value"></span>
             </div>
             <div>
-              <span class="status success"></span><strong>Reported online</strong><span class="value"></span>
+              <span class="status success">{{ complete_count }}</span><strong>Reported online</strong><span class="value"></span>
             </div>
             <br style="clear:both;" />
           </div>
         </div>
         <div class="goal-stats">
           <!-- please keep this 'funky' markup; it has an impact on the display of the bar components -->
-          <span class="danger"></span
-          ><span class="warning"></span
-          ><span class="success"></span>
+          <span class="danger" style="width: {{ exploring_count | times: 100 | divided_by: overall_indicator_count }}%"></span
+          ><span class="warning" style="width: {{ in_progress_count | times: 100 | divided_by: overall_indicator_count }}%"></span
+          ><span class="success" style="width: {{ complete_count | times: 100 | divided_by: overall_indicator_count }}%"></span>
         </div>
       </div>
     <!--</li>-->
@@ -40,6 +46,15 @@
   {% assign sdg_goals = site.data.sdg_goals %}
     <!--<ul style="list-style-type: decimal; margin-left: 50px;margin-bottom: 30px;margin-top:30px;">-->
       {% for goal in sdg_goals %}
+
+        {% assign indicators = site.data.sdg_indicator_metadata | where:'goal', goal.goal %}
+      
+        {% assign goal_indicators = site.indicators | where: 'sdg_goal', goal.goal %}
+        {% assign goal_indicator_count = goal_indicators | size %}
+        {% assign exploring_count = goal_indicators | where: 'reporting_status', 'notstarted' | size %}
+        {% assign in_progress_count = goal_indicators | where: 'reporting_status', 'inprogress' | size %}
+        {% assign complete_count = goal_indicators | where: 'reporting_status', 'complete' | size %}
+
         <!--<li>-->
         <div class="goal" data-goalid="{{ goal.goal }}">
           <div class="frame">
@@ -50,27 +65,27 @@
           <div class="details">
             <h3 class="status-goal">
               <a href="{{ site.baseurl }}/{{ goal.short | slugify }}/">{{ goal.short }}</a>
-              <span class="total"><span></span> indicators</span> 
+              <span class="total">{{ indicators | size }}<span></span> indicators</span> 
             </h3>
             <div class="summary">
               <div class="statuses">
                 <div>
-                  <span class="status danger"></span><strong>Exploring data sources</strong><span class="value"></span>
+                  <span class="status danger">{{ exploring_count }}</span><strong>Exploring data sources</strong><span class="value"></span>
                 </div>
                 <div>
-                  <span class="status warning"></span><strong>Statistics in progress</strong><span class="value"></span>
+                  <span class="status warning">{{ in_progress_count }}</span><strong>Statistics in progress</strong><span class="value"></span>
                 </div>
                 <div>
-                  <span class="status success"></span><strong>Reported online</strong><span class="value"></span>
+                  <span class="status success">{{ complete_count }}</span><strong>Reported online</strong><span class="value"></span>
                 </div>
                 <br style="clear:both;" />
               </div>
             </div>
             <div class="goal-stats">
               <!-- please keep this 'funky' markup; it has an impact on the display of the bar components -->
-              <span class="danger"></span
-              ><span class="warning"></span
-              ><span class="success"></span>
+              <span class="danger" style="width: {{ exploring_count | times: 100 | divided_by: goal_indicator_count }}%"></span
+              ><span class="warning" style="width: {{ in_progress_count | times: 100 | divided_by: goal_indicator_count }}%"></span
+              ><span class="success" style="width: {{ complete_count | times: 100 | divided_by: goal_indicator_count }}%"></span>
             </div>
             <div class="divider">
             </div>

--- a/assets/js/reportingStatus.js
+++ b/assets/js/reportingStatus.js
@@ -82,8 +82,6 @@ $(function() {
             });
   
             $(el).find('span.value:eq(' + index + ')').text(data.percentages[index] + '%');
-            $(el).find('span.status:eq(' + index + ')').text(data.counts[index]);
-            $(el).find('h3.status-goal span.total span').text(data.totalCount);
           }); 
         };
 


### PR DESCRIPTION
This fixes #326, which is part of #307 and allows users to view reporting status information _without_ JavaScript.

In terms of progressive enhancement, JS adds percentages text _and_ coloured bars. Why aren't these static? Well, it seems that Liquid does some unfortunate rounding, so percentages may not add up to 100. I made a decision to give people the information they needed, but put a bit of 'icing on the cake' to finish things off for those with JS enabled.

<img width="678" alt="screen shot 2017-09-22 at 11 48 06" src="https://user-images.githubusercontent.com/2493614/30741583-4712de20-9f8d-11e7-8515-cd8af6d850c8.png">

Without JS, the page looks like the screenshot, above.