### PR TITLE
Update to chart.js version 2.7 fixes #338

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,7 +4,7 @@
 <script src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script src="//cdn.datatables.net/1.10.13/js/dataTables.bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.6.0/Chart.bundle.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.0/Chart.bundle.min.js"></script>
 <script src='{{ site.baseurl }}/assets/js/sdg.js?v={{ cache_bust }}'></script>
 <script>
 $(function() {


### PR DESCRIPTION
Version 2.7 ditches the `iframe`, so the accessibility issues has gone.