### PR TITLE
Charts - ooh haven't you grown!

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -47,7 +47,7 @@ $(function() {
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData',
-        maxChartHeight: 750
+        maxChartHeight: 600
       }),
       controller = new indicatorController(model, view);
       controller.initialise();

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -10,8 +10,10 @@ var indicatorView = function (model, options) {
   this._chartInstance = undefined;
   this._rootElement = options.rootElement;
   
+  var chartHeight = screen.height < options.maxChartHeight ? screen.height : options.maxChartHeight;
+
   $('.plot-container', this._rootElement) 
-    .css('height', Math.min(options.maxChartHeight, (screen.height - 450 /* 450px magic number, considering other design elements */)) + 'px'); 
+    .css('height', chartHeight + 'px'); 
 
   this._model.onDataComplete.attach(function (sender, args) {
 


### PR DESCRIPTION
Chart height was based on screen height, and the previous code for deriving the chart height wasn't quite right for devices with smaller vertical resolutions.

Hopefully this resolves things.

