### PR TITLE
Fixes #388 adds headline viewable without js

### DIFF
--- a/_includes/components/headline.html
+++ b/_includes/components/headline.html
@@ -1,0 +1,24 @@
+{% capture headline_name %}headlines_{{page.indicator | slugify }}{% endcapture %} 
+{% assign sdg_headline_data = site.data.headlines[headline_name] %} 
+
+<h3>Headline data</h3>
+
+<a href="{{ site.baseurl }}/data/headlines/{{ headline_name }}.csv" class="btn btn-primary btn-download" download='{{ dataset_name }}.csv'>Download headline CSV</a>
+
+<table class="table-responsive table table-hover dataTable no-footer" role="grid">
+  <!-- <caption>Headline data</caption> -->
+  <thead>
+  {% for column in sdg_headline_data[0] %}
+      <th scope="col">{{ column[0] }}</th>
+  {% endfor %}
+  </thead>
+  <tbody>
+  {% for row in sdg_headline_data %}
+      <tr>
+      {% for cell in row %}
+          <td>{{ cell[1] }}</td>
+      {% endfor %}
+      </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -93,7 +93,7 @@
           {% endif %}
           <p>Unit of Measurement: {{ page.computation_units }}</p>     
           <a href="{{ site.baseurl }}/data/{{ dataset_name }}.csv" class="btn btn-primary btn-download" download='{{ dataset_name }}.csv'>Download source CSV</a>
-          <div id="datatables"></div>
+          <div id="datatables">{% include components/headline.html %}</div>
         </div>
       {% endif %}
       <div role="tabpanel" class="tab-pane {% if show_data != true %}active{% endif %}" id="metadata">

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -317,7 +317,7 @@ var indicatorModel = function (options) {
     
     // all units for headline data
     tableData.push({
-      title: 'Headline for ' + this.country,
+      title: 'Headline data',
       headings: that.selectedUnit ? ['Year', 'Units', 'Value'] : ['Year', 'Value'],
       data: _.map(headline, function (d) {
         return that.selectedUnit ? [d.Year, d.Units, d.Value] : [d.Year, d.Value];


### PR DESCRIPTION
* Table is built in `_includes/components/headline.html`
* Table is added to the `#datatables` div which is automatically overwritten when JS fires up
* Changed "Headline for UK" to "Headline data"

Seeing how this looks pretty good I wonder if we disable the JavaScript override for now? We needed it when we had the pivot tables but it's not doing much anymore.