### PR TITLE
Showing children 

### DIFF
--- a/_includes/components/fields-template.html
+++ b/_includes/components/fields-template.html
@@ -1,6 +1,6 @@
 <script type="text/template" id="item_template">
   <% _.each(series, function(seriesItem) { %>
-    <div class="variable-selector<% if(allowedFields.indexOf(seriesItem.field) == -1) { %> disallowed<% }%>" data-field="<%=seriesItem.field%>">
+    <div class="variable-selector<% if(allowedFields.indexOf(seriesItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=seriesItem.field%>">
       <h5><%=seriesItem.field%><i class="fa fa-chevron-down"></i></h5>
       <div class="bar">
         <div class="selected"></div>
@@ -14,6 +14,13 @@
           <label><input type="checkbox" value="<%=item.value%>" data-field="<%=seriesItem.field%>" /><%=item.value%></label>
         <% }); %>
       </div>
+      
+      <% if(allowedFields.indexOf(seriesItem.field) == -1) { %> 
+        <div class="variable-hint">
+          Selectable when '<%= _.findWhere(edges, { To: seriesItem.field }).From %>' is selected
+        </div>
+      <% }%>
+
     </div>
   <% }); %>
 </script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,8 +1,8 @@
 <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-<script src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
-<script src="//cdn.datatables.net/1.10.13/js/dataTables.bootstrap.min.js"></script>
+<script src="//cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+<script src="//cdn.datatables.net/1.10.16/js/dataTables.bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.0/Chart.bundle.min.js"></script>
 <script src='{{ site.baseurl }}/assets/js/sdg.js?v={{ cache_bust }}'></script>

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -643,12 +643,15 @@ h5 + .btn-download {
       margin-right: 8px;
       margin-bottom: 10px;
 
-      &.disallowed {
-        display: none;
-      }
-
       &:hover {
         border-color: #555;
+      }
+
+      .variable-hint {
+        display: none;
+        padding-left: 7px;
+        margin-top: -7px;
+        color: #666;
       }
 
       .variable-options {
@@ -705,6 +708,40 @@ h5 + .btn-download {
             background: #f5f3f3;
           }
         }
+      }
+
+      &.child {
+        margin-left: 20px;
+        width: calc(100% - 20px);
+      }
+
+      &.disallowed {
+        .bar {
+          display: none;
+        }
+
+        .variable-hint {
+          display: block;
+        }
+
+        .variable-options {
+          > div { 
+            display: none;
+          }
+
+          input {
+            display: none;
+          }
+
+          label {
+            cursor: default;
+            &:hover {
+              background: white;
+            }
+          }
+        }
+
+        padding-bottom: 5px;
       }
     }
   }

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -421,7 +421,8 @@ var indicatorModel = function (options) {
 
       this.onSeriesComplete.notify({
         series: this.fieldItemStates,
-        allowedFields: this.allowedFields
+        allowedFields: this.allowedFields,
+        edges: this.edgesData
       });
       this.onUnitsComplete.notify({
         units: this.units

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -112,7 +112,11 @@ var indicatorView = function (model, options) {
   });
 
   $(this._rootElement).on('click', '#fields label', function (e) {
-    $(this).find(':checkbox').trigger('click');
+
+    if(!$(this).closest('.variable-options').hasClass('disallowed')) {
+      $(this).find(':checkbox').trigger('click');      
+    }
+
     e.preventDefault();
     e.stopPropagation();
   });
@@ -154,10 +158,10 @@ var indicatorView = function (model, options) {
   $(this._rootElement).on('click', ':checkbox', function(e) {
 
     // don't permit excluded selections:
-    if($(this).parent().hasClass('excluded')) {
+    if($(this).parent().hasClass('excluded') || $(this).closest('.variable-selector').hasClass('disallowed')) {
       return;
     }
-
+    
     updateWithSelectedFields();
 
     e.stopPropagation();
@@ -185,7 +189,8 @@ var indicatorView = function (model, options) {
     
         $('#fields').html(template({
             series: args.series,
-            allowedFields: args.allowedFields
+            allowedFields: args.allowedFields,
+            edges: args.edges
         }));
     } else {
       $(this._rootElement).addClass('no-series');


### PR DESCRIPTION
Children are shown immediately; not only their 'headings', but also their possibilities. Children are indented underneath their parents and when no parent items are selected, a hint is shown and the items aren't selectable. Select a parent and the child's items are selectable (and the hint disappears).

Hopefully this PR shows no-nonsense help and intuitive relationships between data items.