### PR TITLE
Test if number of indicators is divisible by 4 

### DIFF
--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -61,7 +61,10 @@
         </div>
     {% cycle 'end row' : '', '', '', '</div>' %}
     {% endfor %}
-  </div>
+	 	{% assign last_row = indicators.size | modulo:4 %}
+		{% if last_row != 0 %}
+			</div>
+		{% endif %}
 </div>
 
 {% include footer.html %}


### PR DESCRIPTION
and close div accordingly. to solve the issue of having too many closing div tags if the end of the row closes the div twice.