### PR TITLE
Hide all child field values that don't have data

### DIFF
--- a/_includes/components/fields-template.html
+++ b/_includes/components/fields-template.html
@@ -19,6 +19,9 @@
         <div class="variable-hint">
           Selectable when '<%= _.findWhere(edges, { To: seriesItem.field }).From %>' is selected
         </div>
+        <div class="no-data-hint">
+          No options available because of filters above
+        </div>
       <% }%>
 
     </div>

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -709,6 +709,10 @@ h5 + .btn-download {
           &:hover {
             background: #f5f3f3;
           }
+
+          &[data-has-data="false"] {
+            display: none;
+          }
         }
       }
 

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -754,7 +754,7 @@ h5 + .btn-download {
         padding-bottom: 5px;
       }
 
-      &[data-has-data="false"] {
+      &[data-has-data="false"]:not(.disallowed) {
         .no-data-hint {
           display: block;
         }

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -649,6 +649,7 @@ h5 + .btn-download {
         border-color: #555;
       }
 
+      .no-data-hint,
       .variable-hint {
         display: none;
         padding-left: 7px;
@@ -709,10 +710,6 @@ h5 + .btn-download {
           &:hover {
             background: #f5f3f3;
           }
-
-          &[data-has-data="false"] {
-            display: none;
-          }
         }
       }
 
@@ -721,13 +718,10 @@ h5 + .btn-download {
         width: calc(100% - 20px);
       }
 
+      &[data-has-data="false"],
       &.disallowed {
         .bar {
           display: none;
-        }
-
-        .variable-hint {
-          display: block;
         }
 
         .variable-options {
@@ -748,6 +742,17 @@ h5 + .btn-download {
         }
 
         padding-bottom: 5px;
+      }
+
+      &[data-has-data="false"] {
+        .no-data-hint {
+          display: block;
+        }
+      }
+      &.disallowed {
+        .variable-hint {
+          display: block;
+        }
       }
     }
   }

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -710,6 +710,16 @@ h5 + .btn-download {
           &:hover {
             background: #f5f3f3;
           }
+
+          &[data-has-data="false"] {
+            cursor: default;
+            &:hover {
+              background: white;
+            }
+            input {
+              display: none;
+            }
+          }
         }
       }
 

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -37,6 +37,7 @@ var indicatorModel = function (options) {
   this.selectedUnit = undefined;
   this.fieldValueStatuses = [];
   this.userInteraction = {};
+  this.validParentsByChild = {};
 
   // initialise the field information, unique fields and unique values for each field:
   (function initialise() {
@@ -49,11 +50,34 @@ var indicatorModel = function (options) {
         values: _.map(_.chain(that.data).pluck(field).uniq().filter(function(f) { return f; }).value(),
           function(f) { return {
             value: f,
-            state: 'default'
+            state: 'default',
+            hasData: true
           };
         })
       };
     });    
+
+    // Set up the parentValuesByChildValue object, which lists the parent field
+    // values that should be associated with each child field value.
+    var parentFields = _.pluck(that.edgesData, 'From');
+    var childFields = _.pluck(that.edgesData, 'To');
+    that.validParentsByChild = {};
+    _.each(childFields, function(childField, fieldIndex) {
+      var fieldItemState = _.findWhere(that.fieldItemStates, {field: childField});
+      var childValues = _.pluck(fieldItemState.values, 'value');
+      var parentField = parentFields[fieldIndex];
+      that.validParentsByChild[childField] = {};
+      _.each(childValues, function(childValue) {
+        var rowsWithParentValues = _.filter(that.data, function(row) {
+          var childMatch = row[childField] == childValue;
+          var parentNotEmpty = row[parentField];
+          return childMatch && parentNotEmpty;
+        });
+        var parentValues = _.pluck(rowsWithParentValues, parentField);
+        parentValues = _.uniq(parentValues);
+        that.validParentsByChild[childField][childValue] = parentValues;
+      });
+    });
 
     var extractUnique = function(prop) {
       return _.chain(that.data).pluck(prop).uniq().sortBy(function(year) {
@@ -151,9 +175,27 @@ var indicatorModel = function (options) {
     _.each(parentFields, function(parentField) {
       if(_.contains(selectedFields, parentField)) {
         // resinstate
-        that.allowedFields = that.allowedFields.concat(
-          _.chain(that.edgesData).where({ 'From' : parentField }).pluck('To').value()
-        );
+        var childFields = _.chain(that.edgesData).where({ 'From' : parentField }).pluck('To').value();
+        that.allowedFields = that.allowedFields.concat(childFields);
+        // check each value in the child fields to see if it has data in common
+        // with the selected parent value.
+        var selectedParent = _.find(that.selectedFields, function(selectedField) {
+          return selectedField.field == parentField;
+        });
+        _.each(that.fieldItemStates, function(fieldItem) {
+          // We only care about child fields.
+          if (_.contains(childFields, fieldItem.field)) {
+            _.each(fieldItem.values, function(childValue) {
+              var hasData = false;
+              _.each(selectedParent.values, function(parentValue) {
+                if (_.contains(that.validParentsByChild[fieldItem.field][childValue.value], parentValue)) {
+                  hasData = true;
+                }
+              });
+              childValue.hasData = hasData;
+            });
+          }
+        });
       }
     });
 

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -57,7 +57,7 @@ var indicatorModel = function (options) {
       };
     });    
 
-    // Set up the parentValuesByChildValue object, which lists the parent field
+    // Set up the validParentsByChild object, which lists the parent field
     // values that should be associated with each child field value.
     var parentFields = _.pluck(that.edgesData, 'From');
     var childFields = _.pluck(that.edgesData, 'To');

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -48,7 +48,7 @@ var indicatorModel = function (options) {
       return {
         field: field,
         hasData: true,
-        values: _.map(_.chain(that.data).pluck(field).uniq().filter(function(f) { return f; }).value(),
+        values: _.map(_.chain(that.data).pluck(field).uniq().filter(function(f) { return f; }).sort().value(),
           function(f) { return {
             value: f,
             state: 'default',

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -47,6 +47,7 @@ var indicatorModel = function (options) {
       }), function(field) {
       return {
         field: field,
+        hasData: true,
         values: _.map(_.chain(that.data).pluck(field).uniq().filter(function(f) { return f; }).value(),
           function(f) { return {
             value: f,
@@ -185,15 +186,18 @@ var indicatorModel = function (options) {
         _.each(that.fieldItemStates, function(fieldItem) {
           // We only care about child fields.
           if (_.contains(childFields, fieldItem.field)) {
+            var fieldHasData = false;
             _.each(fieldItem.values, function(childValue) {
-              var hasData = false;
+              var valueHasData = false;
               _.each(selectedParent.values, function(parentValue) {
                 if (_.contains(that.validParentsByChild[fieldItem.field][childValue.value], parentValue)) {
-                  hasData = true;
+                  valueHasData = true;
+                  fieldHasData = true;
                 }
               });
-              childValue.hasData = hasData;
+              childValue.hasData = valueHasData;
             });
+            fieldItem.hasData = fieldHasData;
           }
         });
       }

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -90,7 +90,7 @@ var indicatorView = function (model, options) {
     _.each(args.data, function(fieldGroup) {
       _.each(fieldGroup.values, function(fieldItem) {
         var element = $(view_obj._rootElement).find(':checkbox[value="' + fieldItem.value + '"][data-field="' + fieldGroup.field + '"]');
-        element.parent().addClass(fieldItem.state);
+        element.parent().addClass(fieldItem.state).attr('data-has-data', fieldItem.hasData);
       });
     });
 

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -154,7 +154,14 @@ var indicatorView = function (model, options) {
     var type = $(this).data('type');
     var $options = $(this).closest('.variable-options').find(':checkbox');
 
-    $options.prop('checked', type == 'select');
+    // The clear button can clear all checkboxes.
+    if (type == 'clear') {
+      $options.prop('checked', false);
+    }
+    // The select button must only select checkboxes that have data.
+    if (type == 'select') {
+      $options.not('[data-has-data=false]').prop('checked', true);
+    }
 
     updateWithSelectedFields();
 

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -56,6 +56,9 @@ var indicatorView = function (model, options) {
   this._model.onFieldsCleared.attach(function(sender, args) {
     $(view_obj._rootElement).find(':checkbox').prop('checked', false);
     $(view_obj._rootElement).find('#clear').addClass('disabled');
+    
+    // reset available/unavailable fields
+    updateWithSelectedFields();
 
     // #246
     $(view_obj._rootElement).find('.selected').css('width', '0');

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -93,8 +93,11 @@ var indicatorView = function (model, options) {
         element.parent().addClass(fieldItem.state).attr('data-has-data', fieldItem.hasData);
       });
       // Indicate whether the fieldGroup had any data.
-      var region = $(view_obj._rootElement).find('.variable-selector[data-field="' + fieldGroup.field + '"]');
-      region.attr('data-has-data', fieldGroup.hasData);
+      var fieldGroupElement = $(view_obj._rootElement).find('.variable-selector[data-field="' + fieldGroup.field + '"]');
+      fieldGroupElement.attr('data-has-data', fieldGroup.hasData);
+
+      // Re-sort the items.
+      view_obj.sortFieldGroup(fieldGroupElement);
     });
 
     _.each(args.selectionStates, function(ss) {
@@ -415,4 +418,18 @@ var indicatorView = function (model, options) {
       $(el).append('<hr />');
     });
   };
+
+  this.sortFieldGroup = function(fieldGroupElement) {
+    var sortLabels = function(a, b) {
+      var aObj = { hasData: $(a).attr('data-has-data'), text: $(a).text() };
+      var bObj = { hasData: $(b).attr('data-has-data'), text: $(b).text() };
+      if (aObj.hasData == bObj.hasData) {
+        return (aObj.text > bObj.text) ? 1 : -1;
+      }
+      return (aObj.hasData < bObj.hasData) ? 1 : -1;
+    };
+    fieldGroupElement.find('label')
+      .sort(sortLabels)
+      .appendTo(fieldGroupElement.find('.variable-options'));
+  }
 };

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -160,7 +160,7 @@ var indicatorView = function (model, options) {
     }
     // The select button must only select checkboxes that have data.
     if (type == 'select') {
-      $options.not('[data-has-data=false]').prop('checked', true);
+      $options.parent().not('[data-has-data=false]').find(':checkbox').prop('checked', true)
     }
 
     updateWithSelectedFields();

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -92,6 +92,9 @@ var indicatorView = function (model, options) {
         var element = $(view_obj._rootElement).find(':checkbox[value="' + fieldItem.value + '"][data-field="' + fieldGroup.field + '"]');
         element.parent().addClass(fieldItem.state).attr('data-has-data', fieldItem.hasData);
       });
+      // Indicate whether the fieldGroup had any data.
+      var region = $(view_obj._rootElement).find('.variable-selector[data-field="' + fieldGroup.field + '"]');
+      region.attr('data-has-data', fieldGroup.hasData);
     });
 
     _.each(args.selectionStates, function(ss) {


### PR DESCRIPTION
Here's a possible approach to #1204. I'm new to underscore and this project both, so there are probably more efficient ways to do this. Just throwing this out there in case it helps get the ball rolling. Also some notes:

* This includes CSS to hide the field items without data, but it could be changed to disable them instead.
* More work needed: there should also be some indication of when a child field has 0 available items, similar to the "Selectable when..." message. This could be either hiding the child field altogether (the whole dropdown) or some message like "No options available for this set of filters".