### PR TITLE
pdfs in new window

### DIFF
--- a/_includes/components/metadata.html
+++ b/_includes/components/metadata.html
@@ -14,8 +14,8 @@
             {% endunless %}
 
             {% if page[indicator_metadata.name] contains "http" or page[indicator_metadata.name] contains "mailto" %}
-              <a href="{{ page[indicator_metadata.name] }}">
-                {{ url_text }}
+              <a href="{{ page[indicator_metadata.name] }}" target="_blank">
+                {{ url_text }} <span class="visuallyhidden">opens in a new window</span>
               </a>
             {% endif %}
             

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1073,3 +1073,14 @@ footer {
     } 
   }
 }
+
+.visuallyhidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}


### PR DESCRIPTION
With visually hidden span tag telling screen readers 

Fixes #1074 

It's actually all metadata links that will open in a new window/tab. This doesn't seem such a bad thing anyway, and helps accessibility.