### PR TITLE
No headline data, no problem

### DIFF
--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -450,7 +450,7 @@ var indicatorModel = function (options) {
           .flatten()
           .value();
 
-        var customOrder = orderedEdges.concat(_.difference(_.pluck(this.fieldItemStates, 'field'), orderedEdges))
+        var customOrder = orderedEdges.concat(_.difference(_.pluck(this.fieldItemStates, 'field'), orderedEdges));
 
         // now order the fields:
         this.fieldItemStates = _.sortBy(this.fieldItemStates, function(item) {

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -367,21 +367,31 @@ var indicatorModel = function (options) {
       selectionStates: fieldSelectionInfo
     });
 
-    // headline:
+    // get the headline data:
     var headline = this.getHeadline();
 
-    // headline plot should use the specific unit, if any
-    datasets.push(convertToDataset(that.selectedUnit ? _.filter(headline, function(item) { 
-      return item.Units === that.selectedUnit; }) : headline));
-    
-    // all units for headline data
-    tableData.push({
-      title: 'Headline data',
-      headings: that.selectedUnit ? ['Year', 'Units', 'Value'] : ['Year', 'Value'],
-      data: _.map(headline, function (d) {
-        return that.selectedUnit ? [d.Year, d.Units, d.Value] : [d.Year, d.Value];
-      })
-    });
+    // all units for headline data:
+    if(headline.length) {
+      tableData.push({
+        title: 'Headline data',
+        headings: that.selectedUnit ? ['Year', 'Units', 'Value'] : ['Year', 'Value'],
+        data: _.map(headline, function (d) {
+          return that.selectedUnit ? [d.Year, d.Units, d.Value] : [d.Year, d.Value];
+        })
+      });
+    }
+
+    // headline plot should use the specific unit, if any,
+    // but there may not be any headline data at all, or for the 
+    // specific unit:
+    if(that.selectedUnit) {
+      headline = _.where(headline, { Units : that.selectedUnit });
+    }
+
+    // only add to the datasets if there is any headline data:
+    if(headline.length) {
+      datasets.push(convertToDataset(headline));      
+    }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
     // extract the possible combinations for the selected field values

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -24,6 +24,7 @@ var indicatorModel = function (options) {
   var that = this;
   this.data = options.data;
   this.edgesData = options.edgesData;
+  this.hasHeadline = true;
   this.country = options.country;
   this.indicatorId = options.indicatorId;
   this.chartTitle = options.chartTitle;
@@ -241,6 +242,12 @@ var indicatorModel = function (options) {
         }).join(', ');
       },
       getColor = function(datasetIndex) {
+        
+        // offset if there is no headline data:
+        if(!this.hasHeadline) {
+          datasetIndex += 1;
+        }
+
         if(datasetIndex === 0) {
           return headlineColor;
         } else {
@@ -254,6 +261,12 @@ var indicatorModel = function (options) {
         return datasetIndex === 0 ? headlineColor : colors[datasetIndex];
       },
       getBorderDash = function(datasetIndex) {
+
+        // offset if there is no headline data:
+        if(!this.hasHeadline) {
+          datasetIndex += 1;
+        }
+
         // 0 - 
         // the first dataset is the headline:
         return datasetIndex > colors.length ? [5, 5] : undefined;
@@ -391,6 +404,8 @@ var indicatorModel = function (options) {
     // only add to the datasets if there is any headline data:
     if(headline.length) {
       datasets.push(convertToDataset(headline));      
+    } else {
+      this.hasHeadline = false;
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -13,6 +13,7 @@ var indicatorModel = function (options) {
   this.onFieldsStatusUpdated = new event(this);
   this.onFieldsCleared = new event(this);
   this.onSelectionUpdate = new event(this);
+  this.onNoHeadlineData = new event(this);
   
   // data rounding:
   this.roundingFunc = options.roundingFunc || function(value) {
@@ -408,7 +409,6 @@ var indicatorModel = function (options) {
       this.hasHeadline = false;
     }
 
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////
     // extract the possible combinations for the selected field values
     var combinations = this.getCombinationData(this.selectedFields);
 
@@ -485,6 +485,12 @@ var indicatorModel = function (options) {
       this.onSeriesSelectedChanged.notify({
         series: this.selectedFields
       });
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    if(initial && !this.hasHeadline) {
+      // if there is no initial data, select some:
+      this.onNoHeadlineData.notify();
     }
   };
 };

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -30,6 +30,10 @@ var indicatorView = function (model, options) {
     view_obj.createTables(args);
   });
 
+  this._model.onNoHeadlineData.attach(function() {
+    $('#fields .variable-options :checkbox:eq(0)').trigger('click');
+  });
+
   this._model.onSeriesComplete.attach(function (sender, args) {
     view_obj.initialiseSeries(args);
   });
@@ -228,6 +232,7 @@ var indicatorView = function (model, options) {
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        spanGaps: true,
         scales: {
           xAxes: [{
             gridLines: {

--- a/data/edges/edges_11-6-2.csv
+++ b/data/edges/edges_11-6-2.csv
@@ -1,2 +1,2 @@
 From,To
-Size of Particulate Matter,City
+Size of particulate matter,City


### PR DESCRIPTION
This PR resolves a number of issues relating to the lack of headline data. 

The code expected there to be headline data, but carried on if it didn't find any. However, plotting an empty array as a series caused some issues when showing other data series on the same chart. (#516 and #1202)

The changes identify that headline data is not present (it also takes into account the 'unit of measurement' if it is relevant) and automatically selects the _first_ item for the _first_ 'category'.