### PR TITLE
0 to hero (0s are now shown on the charts)

### DIFF
--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -76,7 +76,11 @@ var indicatorModel = function (options) {
 
     // prepare the data according to the rounding function:
     that.data = _.map(that.data, function(item) {
-      item.Value = that.roundingFunc(item.Value);
+
+      // only apply a rounding function for non-zero values:
+      if(item.Value != 0) {
+        item.Value = that.roundingFunc(item.Value);        
+      }
 
       // remove any undefined/null values:
       _.each(Object.keys(item), function(key) {


### PR DESCRIPTION
This fixes the 'where are my 0s?' I tracked it down to the rounding function, which should not be allowed to work with 0s. It was changing them to `NaN`s.