### PR TITLE
Fixes overlapping nav elements at 'medium' viewport widths

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -326,6 +326,19 @@ header {
   }
 }
 
+@media only screen and (min-width: 769px) and (max-width: 991px)  {
+  .navbar {
+    width: 100%;
+    ul.navbar-nav {
+      float: none;
+      margin-top: 40px;
+    }
+  }
+
+  #search { 
+    margin-top: -100px;
+  }
+}
 
 h1,
 h2,


### PR DESCRIPTION
There was an issue with overlapping nav elements between 769 and 991 pixels viewport width.

This PR moves seems to fix the issue.