### PR TITLE
Fixes mobile menu 'Search' heading

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -348,17 +348,13 @@ header {
         cursor: pointer;
 
         &.active {
-          background: #3D3D3D;
+          background: #58595B;
         }
 
         span {
           color: #E5E6E7;
           display: block;
           padding: 15px;
-        }
-
-        &:nth-child(2) {
-          border-left: 1px solid white;
         }
       }
     }
@@ -376,7 +372,7 @@ header {
       font-size: 0.938em;
 
       li {
-
+        cursor: pointer;
         a {
           display: block;
           background: #58595B;

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,11 +1,11 @@
 $(function() {
 
-  var topLevelSearchLink = $('.top-level a:eq(1)');
+  var topLevelSearchLink = $('.top-level span:eq(1)');
 
   var resetForSmallerViewport = function() {
     topLevelSearchLink.text('Search');
     $('.top-level li').removeClass('active');
-    $('.top-level a').removeClass('open');
+    $('.top-level span').removeClass('open');
   };  
 
   $('.top-level span').click(function() {
@@ -28,6 +28,10 @@ $(function() {
       } else {
         $(this).text('Search');
       }
+    } else {
+      // menu click, always hide search:
+      topLevelSearchLink.removeClass('open');
+      topLevelSearchLink.text('Search');
     }
 
     if(!wasVisible) {


### PR DESCRIPTION
I fixed the 'search' heading text with some extra code. I'm sure this was working before, but the steps to reproduce were:

1 - Click Search (note that the heading changes to 'hide')
2 - Click menu (search disappears, as expected)
3 - Click Search and observe correct behaviour (as in step 1)
4 - Click Search and observe that text stays as 'hide')

Step 4 is no more.