### PR TITLE
Fixes mobile indicator heading slash/wrap/issue

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -547,6 +547,17 @@ h5 + .btn-download {
       font-size: 0.938em;
     }
   }
+  h2 {
+    font-size: 1.5em;
+
+    @media only screen and (min-width: 768px) {
+      font-size: 1.8em;
+    }
+
+    @media only screen and (min-width: 992px) {
+      font-size: 2.2em;
+    }
+  }
   h3 {
     @media only screen and (max-width: 480px) {
       font-size: 0.813em;


### PR DESCRIPTION
As it turns out, lower viewport widths still suffer a little from the 'space under the icon' issue, although I don't think it's as bad as it was before because the font size has been reduced at lower viewport widths.

The smaller font also means that the slash/wrap/issue has gone away, although if/you/wanted/more/slashes/in/your/title/the/problem/may/return. However, I think that generally, we won't come across such a long heading. (Unless somebody knows different).