### PR TITLE
Allows more than 13 columns for disaggregation in the Table tab

### DIFF
--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -472,7 +472,6 @@ var indicatorModel = function (options) {
     // restrict count if it exceeds the limit:
     if(filteredDatasets.length > maxDatasetCount) {
       datasetCountExceedsMax = true;
-      filteredDatasets = filteredDatasets.slice(0, maxDatasetCount);
     }
 
     _.chain(filteredDatasets)
@@ -492,7 +491,7 @@ var indicatorModel = function (options) {
       
     this.onDataComplete.notify({
       datasetCountExceedsMax: datasetCountExceedsMax,
-      datasets: datasets,
+      datasets: datasetCountExceedsMax ? datasets.slice(0, maxDatasetCount) : datasets,
       labels: this.years,
       headlineTable: headlineTable,
       selectionsTable: selectionsTable,


### PR DESCRIPTION
`slice`ing is done further down in the code for the `datasets` variable based on whether the count exceeds the `maxDatasetCount` value.

The table data is currently not restricted.