### PR TITLE
Move global metadata into its own tab #2022 

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -14,30 +14,6 @@
 <script src="//cdn.jsdelivr.net/bluebird/3.5.0/bluebird.min.js"></script>
 <script>
 $(function() {
-      $('#metadata .collapsible h3').click(function() {
-      var $container = $(this).closest('div'),
-          $article = $(this).next('article'),
-          $span = $(this).find('span');
-
-      $article.slideToggle(function() {
-        if($container.hasClass('expanded')) {
-          $container.removeClass('expanded');
-          $container.addClass('collapsed');
-          $span.html(' (Expand)');
-        } else {
-          $container.removeClass('collapsed');
-          $container.addClass('expanded');
-          $span.html(' (Collapse)');
-        }
-      });
-    });
-
-    $('#metadata .collapsible h3').keypress(function (e) {
-      if(e.which == 13) { // Enter key
-        $(this).trigger('click');
-      };
-    });
-
     if($('#indicatorData').length) {
       var domData = $('#indicatorData').data();
 

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -116,7 +116,10 @@
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
           <li role="presentation" class="nav-item active">
-            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab">Metadata</a>
+            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab">National Metadata</a>
+          </li>
+          <li role="presentation" class="nav-item">
+            <a class="nav-link" data-toggle="tab" href="#globalmetadata" aria-controls="globalmetadata" role="tab">Global Metadata</a>
           </li>
           <li role="presentation" class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#sources" aria-controls="sources" role="tab">Sources</a>
@@ -132,8 +135,8 @@
         <div class="tab-content">
           <div role="tabpanel" class="tab-pane active" id="metadata">
             <!-- National Metadata -->
-            <div class="collapsible expanded">
-              <h3 tabindex='0'>National Metadata<span> (Collapse)</span></h3>
+            <div > <!-- formerly class="collapsible expanded" -->
+              <h3 tabindex='0'>National Metadata</h3>
               <article>
                 <p>This table provides metadata for the actual indicator available from {{ site.country.name }} statistics closest to the corresponding global
                   SDG indicator. Please note that even when the global SDG indicator is fully available from {{ site.country.adjective }} statistics, this table
@@ -142,15 +145,17 @@
               </article>
             </div>
             <!-- Method of Computation -->
-            <div class="collapsible collapsed">
-              <h3 tabindex='0'>How the {{ site.country.name }} Indicator is Calculated<span> (Expand)</span></h3>
+            <div > <!-- formerly class="collapsible collapsed" -->
+              <h3 tabindex='0'>How the {{ site.country.name }} Indicator is Calculated</h3>
               <article>
                 {% include components/metadata.html scope='computation' %}
               </article>
             </div>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="globalmetadata">
             <!-- Global Metadata -->
-            <div class="collapsible collapsed">
-              <h3 tabindex='0'>Global Metadata<span> (Expand)</span></h3>
+            <div> <!-- formerly <div class="collapsible expanded"> -->
+              <h3 tabindex='0'>Global Metadata</h3>
               <article>
                 <p>This table provides information on metadata for SDG indicators as defined by the UN Statistical Commission. <a href="https://unstats.un.org/sdgs/metadata/">Complete global metadata</a> is provided by the UN Statistics Division.</p>
                 {% include components/metadata.html scope='global' %}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -964,6 +964,7 @@ h5 + .btn-download {
       border: none;
       a {
         border: none;
+        padding-left: 5px;
         &:hover {
           background: none;
         }


### PR DESCRIPTION
* Global Netadata and National Metadata tab
* Removed collapsible sections (including js in scripts.html). This hopefully simplifies a few accessibility issues we were having.

See https://mangothecat.github.io/sdg-indicators/3-3-2/ for a live example.