### PR TITLE
Tidier legend

### DIFF
--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -12,6 +12,7 @@
     <div class="plot-container">
         {% include {{graph_template}} data=include.data %}
     </div>
+    <div id="plotLegend"></div>
 
     <div id="chartSelectionDownload"></div>    
     

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -32,6 +32,7 @@ $(function() {
       }),
       view  = new indicatorView(model, {
         rootElement: '#indicatorData',
+        legendElement: '#plotLegend',
         maxChartHeight: 600,
         tableColumnDefs: [
           { maxCharCount: 25 }, // nowrap

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -939,6 +939,34 @@ h5 + .btn-download {
   #chartSelectionDownload {
     margin-top: -40px;
     margin-bottom: 10px;
+    clear: left;
+  }
+
+  #legend {
+    padding-left: 0;
+    li {
+      font-size: 13px;
+      list-style-type: none;
+      float: left;
+      margin-right: 10px;
+      color: #666;
+      line-height: 18px;
+    }
+    .swatch {
+      display: inline-block;
+      width: 45px;
+      height: 15px;
+      margin-right: 3px;
+    }
+    span {
+      vertical-align: middle;
+      line-height: 18px;
+    }
+    &:after {
+      content: "";
+      display: table;
+      clear: both;
+    }
   }
 
   canvas {

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -958,6 +958,10 @@ h5 + .btn-download {
       &:hover {
         background: #eee;
       }
+
+      &.notshown {
+        text-decoration: line-through;
+      }
     }
     .swatch {
       display: inline-block;

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -949,7 +949,7 @@ h5 + .btn-download {
     li {
       font-size: 13px;
       list-style-type: none;
-      display: inline;
+      display: inline-block;
       color: #666;
       line-height: 18px;
       cursor: pointer;
@@ -968,6 +968,12 @@ h5 + .btn-download {
       width: 45px;
       height: 15px;
       margin-right: 3px;
+
+      &.dashed {
+        background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAABCAYAAADn9T9+AAAAFklEQVQImWP8////fwY0wMjIyIguBgCaAgQCms5tJwAAAABJRU5ErkJggg==');
+        background-repeat: repeat;
+        background-position: -5px 0;
+      }
     }
     span {
       vertical-align: middle;

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -937,17 +937,19 @@ h5 + .btn-download {
   }
 
   #chartSelectionDownload {
-    margin-top: -40px;
+    // margin-top: -40px;
     margin-bottom: 10px;
     clear: left;
   }
 
   #legend {
     padding-left: 0;
+    text-align: center;
+    margin-top: -32px;
     li {
       font-size: 13px;
       list-style-type: none;
-      float: left;
+      display: inline;
       margin-right: 10px;
       color: #666;
       line-height: 18px;

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -950,9 +950,14 @@ h5 + .btn-download {
       font-size: 13px;
       list-style-type: none;
       display: inline;
-      margin-right: 10px;
       color: #666;
       line-height: 18px;
+      cursor: pointer;
+      padding: 5px;
+
+      &:hover {
+        background: #eee;
+      }
     }
     .swatch {
       display: inline-block;

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -309,14 +309,8 @@ var indicatorView = function (model, options) {
             return text.join("");
         },
         legend: {
-          display: true
+          display: false
         },
-        // legend: {
-        //   display: true,
-        //   usePointStyle: false,
-        //   position: 'bottom',
-        //   padding: 20,
-        // },
         title: {
           fontSize: 18,
           fontStyle: 'normal',

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -301,12 +301,14 @@ var indicatorView = function (model, options) {
 
             _.each(chart.data.datasets, function(dataset, datasetIndex) {
               text.push('<li data-datasetindex="' + datasetIndex + '">');
-              text.push('<span class="swatch" style="border:2px solid ' + dataset.borderColor + ';background-color:' + dataset.backgroundColor + '"></span><span>' + dataset.label + '</span>');
+              text.push('<span class="swatch' + (dataset.borderDash ? ' dashed' : '') + '" style="background-color: ' + dataset.backgroundColor + '">');
+              text.push('</span>');
+              text.push(dataset.label);
               text.push('</li>');
             });
             
             text.push('</ul>');
-            return text.join("");
+            return text.join('');
         },
         legend: {
           display: false

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -3,13 +3,12 @@ var indicatorView = function (model, options) {
   "use strict";
   
   var view_obj = this;
-  
-  //this._fieldLimit = 2;
   this._model = model;
   
   this._chartInstance = undefined;
   this._rootElement = options.rootElement;
   this._tableColumnDefs = options.tableColumnDefs;
+  this._legendElement = options.legendElement;
   
   var chartHeight = screen.height < options.maxChartHeight ? screen.height : options.maxChartHeight;
   
@@ -243,6 +242,8 @@ var indicatorView = function (model, options) {
     }
     
     view_obj._chartInstance.update(1000, true);
+
+    $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
   
   this.createPlot = function (chartInfo) {
@@ -279,17 +280,34 @@ var indicatorView = function (model, options) {
         layout: {
           padding: {
             top: 20,
-            // default of 85, but do a rough line count based on 150 characters per line * 20 pixels per
-            // row
+            // default of 85, but do a rough line count based on 150 
+            // characters per line * 20 pixels per row
             bottom: that._model.footnote ? (20 * (that._model.footnote.length / 150)) + 85 : 85
           }
         },
-        legend: {
-          display: true,
-          usePointStyle: false,
-          position: 'bottom',
-          padding: 20
+        legendCallback: function(chart) {
+            console.log(chart.data);
+            var text = [];
+            text.push('<ul id="legend">');
+
+            _.each(chart.data.datasets, function(dataset) {
+              text.push('<li>');
+              text.push('<span class="swatch" style="border:2px solid ' + dataset.borderColor + ';background-color:' + dataset.backgroundColor + '"></span><span>' + dataset.label + '</span>');
+              text.push('</li>');
+            });
+            
+            text.push('</ul>');
+            return text.join("");
         },
+        legend: {
+          display: true
+        },
+        // legend: {
+        //   display: true,
+        //   usePointStyle: false,
+        //   position: 'bottom',
+        //   padding: 20,
+        // },
         title: {
           fontSize: 18,
           fontStyle: 'normal',

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -21,6 +21,11 @@ var indicatorView = function (model, options) {
       $($.fn.dataTable.tables(true)).css('width', '100%');
       $($.fn.dataTable.tables(true)).DataTable().columns.adjust().draw();
     });
+
+    $(view_obj._legendElement).on('click', 'li', function(e) {
+      $(this).toggleClass('notshown');
+      $(this).data('datasetindex');
+    });
   });
   
   this._model.onDataComplete.attach(function (sender, args) {
@@ -290,8 +295,8 @@ var indicatorView = function (model, options) {
             var text = [];
             text.push('<ul id="legend">');
 
-            _.each(chart.data.datasets, function(dataset) {
-              text.push('<li>');
+            _.each(chart.data.datasets, function(dataset, datasetIndex) {
+              text.push('<li data-datasetindex="' + datasetIndex + '">');
               text.push('<span class="swatch" style="border:2px solid ' + dataset.borderColor + ';background-color:' + dataset.backgroundColor + '"></span><span>' + dataset.label + '</span>');
               text.push('</li>');
             });

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -297,9 +297,7 @@ var indicatorView = function (model, options) {
           }
         },
         legendCallback: function(chart) {
-            console.log(chart.data);
-            var text = [];
-            text.push('<ul id="legend">');
+            var text = ['<ul id="legend">'];
 
             _.each(chart.data.datasets, function(dataset, datasetIndex) {
               text.push('<li data-datasetindex="' + datasetIndex + '">');
@@ -403,6 +401,8 @@ var indicatorView = function (model, options) {
         putTextOutputs(graphFooterItems, 0);
       }
     });
+
+    $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
   
   this.toCsv = function (tableData) {

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -24,7 +24,13 @@ var indicatorView = function (model, options) {
 
     $(view_obj._legendElement).on('click', 'li', function(e) {
       $(this).toggleClass('notshown');
-      $(this).data('datasetindex');
+
+      var ci = view_obj._chartInstance,
+          index = $(this).data('datasetindex'),
+          meta = ci.getDatasetMeta(index);
+
+      meta.hidden = meta.hidden === null? !ci.data.datasets[index].hidden : null;
+      ci.update();      
     });
   });
   


### PR DESCRIPTION
This PR resolves #2339 by generating the legend content as html.

Whilst trying to keep everything look as it did before (except for the deficiencies outlined in #2339), generating the html ourselves has the benefit that I am able to add a hover style for legend items, and I dare say that now we have control over the legend text, we can possibly do other things that using the 'default' legend generation didn't permit us to do.

No two ways about it though, 3.2.2 can generate some really long legend titles, and although the clipping has been solved, it still results in a hefty legend.

e4d4082 changes the style for 'dashed' chart items. I think this is clearer than what we had before, but others may disagree.