### PR TITLE
Map data_show_map metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -221,6 +221,13 @@ prose:
             label: Search Keywords
             help: Comma separated keywords for search page
             scope: data
+      - name: data_show_map
+        field:
+            element: checkbox
+            label: Show the map when GeoCodes are present?
+            help: If this box is checked then the prescence of a GeoCode field will trigger a map
+            value: false
+            scope: data
       ######### Chart Info #########
       - name: "graph_type"
         field: 

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -221,6 +221,13 @@ prose:
             label: Search Keywords
             help: Comma separated keywords for search page
             scope: data
+      - name: data_show_map
+        field:
+            element: checkbox
+            label: Show the map when GeoCodes are present?
+            help: If this box is checked then the prescence of a GeoCode field will trigger a map
+            value: false
+            scope: data
       ######### Chart Info #########
       - name: "graph_type"
         field: 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -35,6 +35,7 @@ $(function() {
             data: res.data,
             edgesData: res.edges,
             geoCodeRegEx: domData.geocoderegex,
+            showMap: domData.showmap,
             country: domData.country,
             indicatorId: domData.indicatorid,
             chartTitle: domData.charttitle,

--- a/_indicators/3-9-1.md
+++ b/_indicators/3-9-1.md
@@ -18,6 +18,7 @@ national_indicator_available: >-
 
 national_indicator_periodicity: Annual
 national_geographical_coverage: England
+data_show_map: true
 national_earliest_available_data: '2010'
 
 admin_next_release: To be announced

--- a/_indicators/4-2-1.md
+++ b/_indicators/4-2-1.md
@@ -19,6 +19,7 @@ national_indicator_available: >-
 national_indicator_periodicity: Annual
 national_geographical_coverage: England
 data_geocode_regex: ^E
+data_show_map: true
 national_earliest_available_data: '2013'
 
 admin_next_release: 20-10-18

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -64,7 +64,7 @@
   </div>
   
   <div class="row" id="indicatorData" data-indicatorid='{{dataset_name}}' data-country="{{ page.national_geographical_coverage }}"
-  data-charttitle="{{ page.graph_title }}" data-measurementunit="{{ page.computation_units }}" data-datasource="{{ page.source_organisation_1 }}" data-geographicalarea="{{ page.national_geographical_coverage }}" data-footnote="{{ page.data_footnote }}" data-showdata="{{ show_data }}" data-graphtype="{{ page.graph_type }}" data-geocoderegex="{{ page.data_geocode_regex }}">
+  data-charttitle="{{ page.graph_title }}" data-measurementunit="{{ page.computation_units }}" data-datasource="{{ page.source_organisation_1 }}" data-geographicalarea="{{ page.national_geographical_coverage }}" data-footnote="{{ page.data_footnote }}" data-showdata="{{ show_data }}" data-graphtype="{{ page.graph_type }}" data-geocoderegex="{{ page.data_geocode_regex }}" data-showmap="{{ page.data_show_map }}">
     {% if show_data %}
     <div class="col-md-3">
       <div id="toolbar">

--- a/assets/js/indicatorModel.js
+++ b/assets/js/indicatorModel.js
@@ -56,6 +56,7 @@ var indicatorModel = function (options) {
   this.hasGeoData = false;
   this.geoData = [];
   this.geoCodeRegEx = options.geoCodeRegEx;
+  this.showMap = options.showMap;
 
   // initialise the field information, unique fields and unique values for each field:
   (function initialise() {
@@ -555,7 +556,8 @@ var indicatorModel = function (options) {
         edges: this.edgesData,
         hasGeoData: this.hasGeoData,
         geoData: this.geoData,
-        geoCodeRegEx: this.geoCodeRegEx
+        geoCodeRegEx: this.geoCodeRegEx,
+        showMap: this.showMap
       });
 
 

--- a/assets/js/indicatorView.js
+++ b/assets/js/indicatorView.js
@@ -60,7 +60,7 @@ var indicatorView = function (model, options) {
   this._model.onSeriesComplete.attach(function(sender, args) {
     view_obj.initialiseSeries(args);
 
-    if(args.hasGeoData) {
+    if(args.hasGeoData && args.showMap) {
       view_obj._mapView = new mapView();
       view_obj._mapView.initialise(args.geoData, args.geoCodeRegEx);
     }


### PR DESCRIPTION
This PR results in the map being shown only when the `data_show_map` metadata is present AND set to true. (In addition, the data's GeoCode column must be present, as before.)