### PR TITLE
Build paths

### DIFF
--- a/scripts/build_csvs.py
+++ b/scripts/build_csvs.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 2017-10-04
+
+@author: dougashton
+
+This script builds the website csvs from the data repo
+"""
+
+# %% setup
+
+import sdg.path
+from sdg.path import indicator_path
+import os
+import shutil
+import glob
+
+# %% Write out edges for one csv
+
+
+def build_csv(inid):
+    """
+    For a given ID pull in the raw data and write out the website csv
+
+    Returns:
+        bool: Status
+    """
+    status = True
+
+    in_path = indicator_path(inid, ftype='data', mode='r')
+    out_path = indicator_path(inid, ftype='data', mode='w')
+
+    try:
+        shutil.copy(in_path, out_path)
+    except Exception as e:
+        print(inid, e)
+        return False
+
+    return status
+
+
+# %% Read each csv and run the checks
+
+
+def main():
+    """Run csv checks on all indicator csvs in the data directory"""
+    status = True
+    # Create the place to put the files
+    os.makedirs("data", exist_ok=True)
+    
+    inids = sdg.path.get_ids()
+    print("Building csvs for " + str(len(inids)) + " indicators...")
+    for inid in inids:
+        status = status & build_csv(inid)
+
+    print("Copying goals info...")
+    in_dir = indicator_path(ftype='data', mode = 'r')
+    out_dir = indicator_path(ftype='data', mode = 'w')
+    for f in glob.glob(os.path.join(in_dir, 'sdg*.csv')):
+      shutil.copy(f, out_dir)
+
+    return(status)
+
+if __name__ == '__main__':
+    status = main()
+    if(not status):
+        raise RuntimeError("Failed edge detection")
+    else:
+        print("Success")

--- a/scripts/build_json.py
+++ b/scripts/build_json.py
@@ -181,7 +181,7 @@ def compare_reload(inid, which='edges'):
     """Load the original csv and compare to reloading the JSON you wrote out
     which = 'edges' or 'data'
     """
-    csv_path = indicator_path(inid, ftype=which)
+    csv_path = indicator_path(inid, ftype=which, mode = 'w')
 
     jsn = json.load(open(indicator_path(inid, 'json', mode = 'w')))
 

--- a/scripts/build_metadata.py
+++ b/scripts/build_metadata.py
@@ -6,9 +6,8 @@ Created on Mon Mar 26 13:32:35 2018
 
 
 """
+import os
 # Local modules
-#lib_path = os.path.dirname(os.path.abspath(__file__))
-#sys.path.append(lib_path)
 import yamlmd
 import sdg
 from sdg.path import indicator_path  # local package
@@ -25,12 +24,10 @@ def build_meta(inid):
     fw = indicator_path(inid, ftype='meta', mode='w')
 
     meta = yamlmd.read_yamlmd(fr)
-
     git_update = sdg.git.get_git_updates(inid)
 
     for k in git_update.keys():
         meta[0][k] = git_update[k]
-
     yamlmd.write_yamlmd(meta, fw)
 
     return status
@@ -44,6 +41,10 @@ def main():
     ids = sdg.path.get_ids()
 
     print("Building " + str(len(ids)) + " metadata files...")
+    
+    # Make sure they have somewhere to go
+    out_dir = indicator_path(ftype='meta', mode='w')
+    os.makedirs(out_dir, exist_ok=True)
 
     for inid in ids:
         try:

--- a/scripts/sdg/git.py
+++ b/scripts/sdg/git.py
@@ -34,6 +34,9 @@ def get_git_update(inid, ftype):
     f_dir, f_name = os.path.split(f)
     
     repo = git.Repo(f_dir, search_parent_directories=True)
+    # Need to translate relative to the repo root (this may be a submodule)
+    repo_dir = os.path.relpath(repo.working_dir, os.getcwd())
+    f = os.path.relpath(f, repo_dir)
     
     commit = next(repo.iter_commits(paths=f, max_count=1))
     git_date = str(commit.committed_datetime.date())

--- a/scripts/sdg/path.py
+++ b/scripts/sdg/path.py
@@ -16,9 +16,12 @@ import os
 # Paths to raw data and metadata relative to project root
 # root_dir = os.path.dirname(os.path.realpath(__file__))
 root_dir = ''
-meta_dir = os.path.join(root_dir, '_indicators')
-data_dir = os.path.join(root_dir, 'data')
-
+#in_meta_dir = os.path.join(root_dir, 'ext-data', '_indicators')
+#in_data_dir = os.path.join(root_dir, 'ext-data', 'data')
+in_meta_dir = os.path.join(root_dir, '_indicators')
+in_data_dir = os.path.join(root_dir, 'data')
+out_meta_dir = os.path.join(root_dir, '_indicators')
+out_data_dir = os.path.join(root_dir, 'data')
 
 # %% Get the IDs by scanning the metadata directory
 
@@ -31,7 +34,7 @@ def extract_id(md_path):
 
 
 def get_ids():
-    mds = glob.glob(os.path.join(meta_dir, '*-*.md'))
+    mds = glob.glob(os.path.join(in_meta_dir, '*-*.md'))
     ids = [extract_id(md) for md in mds]
 
     return ids
@@ -67,6 +70,8 @@ def indicator_path(inid=None, ftype='data', mode='r', must_work=False):
 
     prefix = 'indicator_'
     ext = '.csv'
+    data_dir = in_data_dir if mode=='r' else out_data_dir
+    meta_dir = in_meta_dir if mode=='r' else out_meta_dir
     if ftype == 'data':
         path = data_dir
     elif ftype == 'meta':


### PR DESCRIPTION
Related to #2581. In preparation for the repo-split I'm copying over changes that I had to make on test splits. These changes are compatible with the current repo. The main idea is that in `scripts/sdg/path.y` each indicator path in `indicator_path` has a read `r` mode and a `w` write mode. The scripts are all updated so that they use the correct one. When the split is done we just need to change the base path for the read location and we're good to go.